### PR TITLE
Small fixes

### DIFF
--- a/UnitystationLauncher/Models/ServerWrapper.cs
+++ b/UnitystationLauncher/Models/ServerWrapper.cs
@@ -197,7 +197,7 @@ namespace UnitystationLauncher.Models
                     {
                         startInfo = new ProcessStartInfo(exe, $"--server {ServerIP} --port {ServerPort} --refreshtoken {authManager.CurrentRefreshToken} --uid {authManager.UID}");
                     }
-                    startInfo.UseShellExecute = false;
+                    startInfo.UseShellExecute = true;
                     var process = new Process();
                     process.StartInfo = startInfo;
                                         

--- a/UnitystationLauncher/UnitystationLauncher.csproj
+++ b/UnitystationLauncher/UnitystationLauncher.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>


### PR DESCRIPTION
Set useShellExecute to true for client launching and set Output to WinExe to prevent console window opening when opening the hub. (Seeing if it will work on osx)