### PR TITLE
Hacky fix to FileSystemWatcher problems on linux

### DIFF
--- a/UnitystationLauncher/Models/Config.cs
+++ b/UnitystationLauncher/Models/Config.cs
@@ -41,7 +41,8 @@ namespace UnitystationLauncher.Models
         {
             Directory.CreateDirectory(InstallationsPath);
 
-            FileWatcher = new FileSystemWatcher(InstallationsPath) { EnableRaisingEvents = true, IncludeSubdirectories = true };
+            FileWatcher = new FileSystemWatcher(InstallationsPath) { EnableRaisingEvents = true, IncludeSubdirectories = true, 
+                NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName };
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -52,11 +53,10 @@ namespace UnitystationLauncher.Models
                 RootFolder = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
             }
 
-            InstallationChanges = Observable.Merge(
+                InstallationChanges = Observable.Merge(
                 Observable.FromEventPattern<FileSystemEventHandler, FileSystemEventArgs>(
                     h => FileWatcher.Changed += h,
                     h => FileWatcher.Changed -= h)
-                .Do(o => Log.Debug("File refresh: {FileName}", o.EventArgs.Name))
                 .Select(e => Unit.Default),
                 Observable.Return(Unit.Default))
                 .ObserveOn(SynchronizationContext.Current);

--- a/UnitystationLauncher/Models/Installation.cs
+++ b/UnitystationLauncher/Models/Installation.cs
@@ -21,6 +21,8 @@ namespace UnitystationLauncher.Models
 {
     public class Installation
     {
+        private InstallationManager installManager;
+
         private Installation()
         {
             Play = ReactiveCommand.Create(StartImp);
@@ -67,8 +69,7 @@ namespace UnitystationLauncher.Models
             else
             {
                 exe = files.SingleOrDefault(s =>
-                    s.EndsWith("station") &&
-                    (new UnixFileInfo(s).FileAccessPermissions & FileAccessPermissions.UserExecute) > 0);
+                    s.EndsWith("station"));
             }
 
             return exe;
@@ -133,27 +134,32 @@ namespace UnitystationLauncher.Models
                 var response = await msgBox.Show();
                 if (response.Equals("Confirm"))
                 {
-                    Log.Information($"Perform delete of {InstallationPath}");
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                    || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                    {
-                        ProcessStartInfo startInfo;
-                        startInfo = new ProcessStartInfo("rm", $"-r {InstallationPath}");
-                        startInfo.UseShellExecute = false;
-                        var process = new Process();
-                        process.StartInfo = startInfo;
-
-                        process.Start();
-                    }
-                    else
-                    {
-                        DeleteFolder(InstallationPath);
-                    }
+                    DeleteInstallation();
                 }
             }
             catch (Exception e)
             {
                 Log.Error(e, "An exception occurred during the deletion of an installation");
+            }
+        }
+
+        public void DeleteInstallation()
+        {
+            Log.Information($"Perform delete of {InstallationPath}");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                ProcessStartInfo startInfo;
+                startInfo = new ProcessStartInfo("rm", $"-r {InstallationPath}");
+                startInfo.UseShellExecute = false;
+                var process = new Process();
+                process.StartInfo = startInfo;
+
+                process.Start();
+            }
+            else
+            {
+                DeleteFolder(InstallationPath);
             }
         }
 

--- a/UnitystationLauncher/Models/InstallationManager.cs
+++ b/UnitystationLauncher/Models/InstallationManager.cs
@@ -20,7 +20,7 @@ namespace UnitystationLauncher.Models
         {
             installationsSubject = new BehaviorSubject<IReadOnlyList<Installation>>(new Installation[0]);
             Config.InstallationChanges
-                .ThrottleSubsequent(TimeSpan.FromMilliseconds(200))
+                .ThrottleSubsequent(TimeSpan.FromMilliseconds(1000))
                 .Select(f =>
                     Directory.EnumerateDirectories(Config.InstallationsPath)
                         .Select(dir => new Installation(dir))
@@ -50,7 +50,7 @@ namespace UnitystationLauncher.Models
                 }
                 try
                 {
-                   Directory.Delete(i.InstallationPath, true);
+                   i.DeleteInstallation();
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Not the prettiest thing but it works. All I did was add the LastAccess notifier to the FileSystemWatcher and throttled the Observe to 1000ms for the installation update. Lets find a better alternative to this solution after release