### PR TITLE
Prevents servers with non-trusted download URLs from appearing in server list

### DIFF
--- a/UnitystationLauncher/Models/Server.cs
+++ b/UnitystationLauncher/Models/Server.cs
@@ -58,8 +58,7 @@ namespace UnitystationLauncher.Models
 
         public string InstallationName => ForkName + BuildVersion;
 
-        public string Description =>
-            $"BuildVersion: {BuildVersion} - Map: {CurrentMap} - Gamemode: {GameMode} - Time: {InGameTime}";
+        public string Description => $"BuildVersion: {BuildVersion} - Map: {CurrentMap} - Gamemode: {GameMode} - Time: {InGameTime}";
 
         public string InstallationPath => Path.Combine(Config.InstallationsPath, InstallationName);
 

--- a/UnitystationLauncher/Models/Server.cs
+++ b/UnitystationLauncher/Models/Server.cs
@@ -34,6 +34,28 @@ namespace UnitystationLauncher.Models
             RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? LinuxDownload :
             throw new InvalidOperationException("Failed to detect OS");
 
+        public bool HasTrustedUrlSource
+        {
+            get
+            {
+                const string trustedHost = "unitystationfile.b-cdn.net";
+                var urls = new[] { WinDownload, OsxDownload, LinuxDownload };
+                foreach (var url in urls)
+                {
+                    if (string.IsNullOrEmpty(url))
+                    {
+                        return false;
+                    }
+                    var uri = new Uri(url);
+                    if (uri.Scheme != "https" && uri.Host != trustedHost)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
         public string InstallationName => ForkName + BuildVersion;
 
         public string Description =>

--- a/UnitystationLauncher/Models/Server.cs
+++ b/UnitystationLauncher/Models/Server.cs
@@ -47,7 +47,7 @@ namespace UnitystationLauncher.Models
                         return false;
                     }
                     var uri = new Uri(url);
-                    if (uri.Scheme != "https" && uri.Host != trustedHost)
+                    if (uri.Scheme != "https" || uri.Host != trustedHost)
                     {
                         return false;
                     }

--- a/UnitystationLauncher/Models/Server.cs
+++ b/UnitystationLauncher/Models/Server.cs
@@ -36,7 +36,8 @@ namespace UnitystationLauncher.Models
 
         public string InstallationName => ForkName + BuildVersion;
 
-        public string Description => $"BuildVersion: {BuildVersion} - Map: {CurrentMap} - Gamemode: {GameMode} - Time: {InGameTime}";
+        public string Description =>
+            $"BuildVersion: {BuildVersion} - Map: {CurrentMap} - Gamemode: {GameMode} - Time: {InGameTime}";
 
         public string InstallationPath => Path.Combine(Config.InstallationsPath, InstallationName);
 

--- a/UnitystationLauncher/Models/ServerManager.cs
+++ b/UnitystationLauncher/Models/ServerManager.cs
@@ -62,8 +62,9 @@ namespace UnitystationLauncher.Models
             {
                 if (!s.HasTrustedUrlSource)
                 {
-                    Log.Warning($"Server: {s.ServerName} has untrusted download URL and has been omitted in " +
-                                "the server list!");
+                    Log.Warning(
+                        "Server: {ServerName} has untrusted download URL and has been omitted in the server list!",
+                        s.ServerName);
                     continue;
                 }
                 var index = _oldServerList.FindIndex(x => x.Server.ServerIp == s.ServerIp);

--- a/UnitystationLauncher/Models/ServerManager.cs
+++ b/UnitystationLauncher/Models/ServerManager.cs
@@ -60,6 +60,12 @@ namespace UnitystationLauncher.Models
 
             foreach (Server s in serverList.Servers)
             {
+                if (!s.HasTrustedUrlSource)
+                {
+                    Log.Warning($"Server: {s.ServerName} has untrusted download URL and has been omitted in " +
+                                "the server list!");
+                    continue;
+                }
                 var index = _oldServerList.FindIndex(x => x.Server.ServerIp == s.ServerIp);
                 if (index != -1)
                 {
@@ -68,12 +74,6 @@ namespace UnitystationLauncher.Models
                 }
                 else
                 {
-                    if (!HasTrustedUrlSource(s))
-                    {
-                        Log.Warning($"Server: {s.ServerName} has untrusted download URL and has been omitted in " +
-                                    "the server list!");
-                        continue;
-                    }
                     newServerList.Add(new ServerViewModel(s, _authManager));
                 }
             }
@@ -82,25 +82,6 @@ namespace UnitystationLauncher.Models
 
             Refreshing = false;
             return newServerList;
-        }
-
-        private bool HasTrustedUrlSource(Server server)
-        {
-            const string trustedHost = "unitystationfile.b-cdn.net";
-            var urls = new[] { server.WinDownload, server.OsxDownload, server.LinuxDownload };
-            foreach (var url in urls)
-            {
-                if (string.IsNullOrEmpty(url))
-                {
-                    return false;
-                }
-                var uri = new Uri(url);
-                if (uri.Scheme != "https" && uri.Host != trustedHost)
-                {
-                    return false;
-                }
-            }
-            return true;
         }
 
         void RefreshInstalledStates(IReadOnlyList<ServerViewModel> serverList)

--- a/UnitystationLauncher/Models/ServerManager.cs
+++ b/UnitystationLauncher/Models/ServerManager.cs
@@ -68,6 +68,12 @@ namespace UnitystationLauncher.Models
                 }
                 else
                 {
+                    if (!HasTrustedUrlSource(s))
+                    {
+                        Log.Warning($"Server: {s.ServerName} has untrusted download URL and has been omitted in " +
+                                    "the server list!");
+                        continue;
+                    }
                     newServerList.Add(new ServerViewModel(s, _authManager));
                 }
             }
@@ -76,6 +82,25 @@ namespace UnitystationLauncher.Models
 
             Refreshing = false;
             return newServerList;
+        }
+
+        private bool HasTrustedUrlSource(Server server)
+        {
+            const string trustedHost = "unitystationfile.b-cdn.net";
+            var urls = new[] { server.WinDownload, server.OsxDownload, server.LinuxDownload };
+            foreach (var url in urls)
+            {
+                if (string.IsNullOrEmpty(url))
+                {
+                    return false;
+                }
+                var uri = new Uri(url);
+                if (uri.Scheme != "https" && uri.Host != trustedHost)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         void RefreshInstalledStates(IReadOnlyList<ServerViewModel> serverList)


### PR DESCRIPTION
This tries to be a better short term solution for the security issue that would allow any server operator to run arbirtrary code by changing the build download url to a malicious executable.

~~As a consequence, all config files of active servers would have to change and remove the CDN url from their download url, leaving only the rest of the path.~~

closes #105 