### PR TITLE
Corrects path to game executable file in MacOSX

### DIFF
--- a/UnitystationLauncher/Models/Installation.cs
+++ b/UnitystationLauncher/Models/Installation.cs
@@ -37,22 +37,19 @@ namespace UnitystationLauncher.Models
                 return null;
             }
 
-            var files = Directory.EnumerateFiles(path);
             string? exe;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                exe = files.SingleOrDefault(s => Regex.IsMatch(Path.GetFileName(s), @".*station\.exe"));
+                exe = Path.Combine(path, "Unitystation.exe");
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                var archives = Directory.EnumerateDirectories(path);
-                exe = archives.SingleOrDefault(s => Regex.IsMatch(Path.GetFileName(s), @".*station\.app"));
+                exe = Path.Combine(path, "Unitystation.app", "Contents", "MacOS", "unitystation");
             }
             else
             {
-                exe = files.SingleOrDefault(s =>
-                    s.EndsWith("station"));
+                exe = Path.Combine(path, "Unitystation");
             }
 
             return exe;


### PR DESCRIPTION
Bug was pretty easy to fix but a hurdly to understand, fukken MacOSX and their *different* OS. 

This will let StationHub launch the game again on MacOSX.
fixes #114 