### PR TITLE
Switch from webrequest to httpclient

### DIFF
--- a/UnitystationLauncher/Exceptions/ContentLengthNullException.cs
+++ b/UnitystationLauncher/Exceptions/ContentLengthNullException.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace UnitystationLauncher.Exceptions
+{
+    public class ContentLengthNullException : Exception
+    {
+        public ContentLengthNullException(string url)
+        {
+            Url = url;
+        }
+
+        public ContentLengthNullException(string url, string message)
+            : base(message)
+        {
+            Url = url;
+        }
+
+        public ContentLengthNullException(string url, string message, Exception inner)
+            : base(message, inner)
+        {
+            Url = url;
+        }
+
+        public string Url { get; }
+
+        public override String Message => $"{base.Message} Url='{Url}";
+    }
+}

--- a/UnitystationLauncher/Models/Download.cs
+++ b/UnitystationLauncher/Models/Download.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
-using System.Net;
+using System.Net.Http;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Humanizer;
 using ReactiveUI;
 using Serilog;
 using UnitystationLauncher.Infrastructure;
@@ -50,7 +51,7 @@ namespace UnitystationLauncher.Models
         public string ForkName => Installation.GetForkName(InstallationPath);
         public int BuildVersion => Installation.GetBuildVersion(InstallationPath);
 
-        public async Task StartAsync()
+        public async Task StartAsync(HttpClient http)
         {
             Log.Information("Download requested, Installation Path '{Path}', Url '{Url}'", InstallationPath, Url);
 
@@ -63,9 +64,8 @@ namespace UnitystationLauncher.Models
             try
             {
                 Log.Information("Download started...");
-                var webRequest = WebRequest.Create(Url);
-                var webResponse = await webRequest.GetResponseAsync();
-                await using var responseStream = webResponse.GetResponseStream();
+                var request = await http.GetAsync(Url, HttpCompletionOption.ResponseHeadersRead);
+                await using var responseStream = await request.Content.ReadAsStreamAsync();
                 if (responseStream == null)
                 {
                     Log.Error("Could not download from server");
@@ -74,12 +74,14 @@ namespace UnitystationLauncher.Models
 
                 Log.Information("Download connection established");
                 await using var progStream = new ProgressStream(responseStream);
-                Size = webResponse.ContentLength;
+                Size = request.Content.Headers.ContentLength ??
+                       throw new NullReferenceException(nameof(request.Content.Headers.ContentLength));
+
+                using var logProgDisposable = LogProgress(progStream);
 
                 progStream.Progress
                     .Select(p => (int)(p * 100 / Size))
                     .DistinctUntilChanged()
-                    .Do(p => Log.Information("Progress: {Percentage}", p))
                     .Subscribe(p => { Progress = p; });
 
                 await Task.Run(() =>
@@ -103,6 +105,38 @@ namespace UnitystationLauncher.Models
             {
                 Active = false;
             }
+        }
+
+        private IDisposable LogProgress(ProgressStream progStream)
+        {
+            var lastPosition = 0L;
+            var lastTime = DateTime.Now;
+
+            return progStream.Progress
+                .Subscribe(pos =>
+                {
+                    var time = DateTime.Now;
+                    var deltaPos = pos - lastPosition;
+                    var deltaTime = time - lastTime;
+                    var deltaPercentage = deltaPos * 100 / Size;
+                    var percentage = pos * 100 / Size;
+
+                    if (pos != Size)
+                    {
+                        if (deltaPercentage < 25 && deltaTime.TotalSeconds < .25)
+                        {
+                            return;
+                        }
+                    }
+
+                    var speed = deltaPos.Bytes().Per(deltaTime);
+                    Log.Information("Progress: {ProgressPercent}%, Download speed = {DownloadSpeed}",
+                        percentage,
+                        speed.Humanize("#.##"));
+
+                    lastPosition = pos;
+                    lastTime = time;
+                });
         }
 
         public bool CanStart()

--- a/UnitystationLauncher/Models/Download.cs
+++ b/UnitystationLauncher/Models/Download.cs
@@ -79,7 +79,7 @@ namespace UnitystationLauncher.Models
 
                 using var logProgDisposable = LogProgress(progStream);
 
-                progStream.Progress
+                using var progDisposable = progStream.Progress
                     .Select(p => (int)(p * 100 / Size))
                     .DistinctUntilChanged()
                     .Subscribe(p => { Progress = p; });
@@ -90,6 +90,7 @@ namespace UnitystationLauncher.Models
                     try
                     {
                         var archive = new ZipArchive(progStream);
+                        // TODO: Enable extraction cancelling
                         archive.ExtractToDirectory(InstallationPath, true);
 
                         Log.Information("Download completed");
@@ -130,7 +131,7 @@ namespace UnitystationLauncher.Models
                     }
 
                     var speed = deltaPos.Bytes().Per(deltaTime);
-                    Log.Information("Progress: {ProgressPercent}%, Download speed = {DownloadSpeed}",
+                    Log.Information("Progress: {ProgressPercent}%, Speed = {DownloadSpeed}",
                         percentage,
                         speed.Humanize("#.##"));
 

--- a/UnitystationLauncher/Models/Download.cs
+++ b/UnitystationLauncher/Models/Download.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Humanizer;
 using ReactiveUI;
 using Serilog;
+using UnitystationLauncher.Exceptions;
 using UnitystationLauncher.Infrastructure;
 
 namespace UnitystationLauncher.Models
@@ -75,7 +76,7 @@ namespace UnitystationLauncher.Models
                 Log.Information("Download connection established");
                 await using var progStream = new ProgressStream(responseStream);
                 Size = request.Content.Headers.ContentLength ??
-                       throw new NullReferenceException(nameof(request.Content.Headers.ContentLength));
+                       throw new ContentLengthNullException(Url);
 
                 using var logProgDisposable = LogProgress(progStream);
 
@@ -101,6 +102,10 @@ namespace UnitystationLauncher.Models
                         Log.Information("Extracting stopped");
                     }
                 });
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Failed to download Url '{Url}'", Url);
             }
             finally
             {

--- a/UnitystationLauncher/Services/DownloadService.cs
+++ b/UnitystationLauncher/Services/DownloadService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Avalonia.Collections;
 using Serilog;
@@ -10,10 +11,12 @@ namespace UnitystationLauncher.Services
 {
     public class DownloadService
     {
+        private readonly HttpClient _http;
         private readonly AvaloniaList<Download> _downloads;
 
-        public DownloadService()
+        public DownloadService(HttpClient http)
         {
+            _http = http;
             _downloads = new AvaloniaList<Download>();
             Downloads.GetWeakCollectionChangedObservable().Subscribe(x => Log.Information("Downloads changed"));
         }
@@ -36,7 +39,7 @@ namespace UnitystationLauncher.Services
             _downloads.Remove(_downloads.FirstOrDefault(d => d.ForkAndVersion == download.ForkAndVersion));
 
             _downloads.Add(download);
-            await download.StartAsync();
+            await download.StartAsync(_http);
             return download;
         }
 

--- a/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
+++ b/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Humanizer;
 using Mono.Unix;
+using UnitystationLauncher.Exceptions;
 using UnitystationLauncher.Infrastructure;
 using UnitystationLauncher.Models.ConfigFile;
 
@@ -153,7 +154,7 @@ namespace UnitystationLauncher.ViewModels
             Log.Information("Download connection established");
             await using var progStream = new ProgressStream(responseStream);
             var length = request.Content.Headers.ContentLength ??
-                         throw new NullReferenceException(nameof(request.Content.Headers.ContentLength));
+                         throw new ContentLengthNullException(downloadUrl);
 
             progStream.Progress
                 .Select(p => (int)(p * 100 / length))


### PR DESCRIPTION
WebRequest is deprecated and should not be used, this also cleans the logic up slightly and improves logging.
I tested the hub update and (didn't try to launch the updated version) and no exceptions occurred and it successfully ran.