### PR TITLE
Bundling, notarizing and stapling app.

### DIFF
--- a/.github/workflows/dotnetcore-macos.yml
+++ b/.github/workflows/dotnetcore-macos.yml
@@ -1,0 +1,50 @@
+name: .NET Core
+
+on:
+  push:
+    branches:
+      - "develop"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
+      - name: Test
+        run: |
+          dotnet test
+
+      - name: Bundle
+        run: |
+          dotnet restore -r osx-x64
+          dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-x64 -property:Configuration=Release -p:UseAppHost=true
+
+      - name: Sign
+        run: |
+          ~/buildscripts/signapp.sh
+
+      - name: Notarize Release Build
+        uses: devbotsxyz/xcode-notarize@v1
+        with:
+          product-path: "~/publish/Rings.app"
+          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+
+      - name: Staple Release Build
+        uses: devbotsxyz/xcode-staple@v1
+        with:
+          product-path: "~/publish/Rings.app"
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v2
+        with:
+          name: StationHub-osx-x64
+          path: ~/publish

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,6 @@ jobs:
         target-platform:
           - "win-x64"
           - "linux-x64"
-          - "osx-x64"
 
     steps:
       - uses: actions/checkout@v1

--- a/UnitystationLauncher/BuildScripts/signapp.sh
+++ b/UnitystationLauncher/BuildScripts/signapp.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+APP_NAME="~/publish/UnityStationLauncher.app"
+ENTITLEMENTS="./UnityStationLauncher.entitlements"
+SIGNING_IDENTITY="Developer ID: MyCompanyName" # matches Keychain Access certificate name
+
+find "$APP_NAME/Contents/MacOS/"|while read fname; do
+    if [[ -f $fname ]]; then
+        echo "[INFO] Signing $fname"
+        codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$fname"
+    fi
+done
+
+echo "[INFO] Signing app file"
+
+codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$APP_NAME"

--- a/UnitystationLauncher/UnityStationLauncher.entitlements
+++ b/UnitystationLauncher/UnityStationLauncher.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/UnitystationLauncher/UnitystationLauncher.csproj
+++ b/UnitystationLauncher/UnitystationLauncher.csproj
@@ -23,6 +23,17 @@
     <DisablePatch>False</DisablePatch>
     <!-- valid values: Error|Detail|Info -->
     <BeautyLogLevel>Error</BeautyLogLevel>
+    <UseAppHost>true</UseAppHost>
+    <CFBundleName>StationHub</CFBundleName> <!-- Also defines .app file name -->
+    <CFBundleDisplayName>StationHub</CFBundleDisplayName>
+    <CFBundleIdentifier>com.stationhub</CFBundleIdentifier>
+    <CFBundleVersion>1.0.0</CFBundleVersion>
+    <CFBundlePackageType>APPL</CFBundlePackageType>
+    <CFBundleSignature>????</CFBundleSignature>
+    <CFBundleExecutable>StationHub</CFBundleExecutable>
+    <CFBundleIconFile>AppName.icns</CFBundleIconFile> <!-- Will be copied from output directory -->
+    <NSPrincipalClass>NSApplication</NSPrincipalClass>
+    <NSHighResolutionCapable>true</NSHighResolutionCapable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">
@@ -77,5 +88,6 @@
     <PackageReference Include="runtime.any.System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="runtime.any.System.Threading.Timer" Version="4.3.0" />
     <PackageReference Include="runtime.unix.System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="Dotnet.Bundle" Version="*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
A quick first stab at resolving unitystation/unitystation#7926 by (hopefully) bundling the MacOS executable in a signed and notarized application.

I roughly followed the guidlines outlined in the below link, but I am not a regular MacOS user/developer so I am unable to test this locally and might need some additional devops help in getting this finished.

https://docs.avaloniaui.net/docs/distribution-publishing/macos#dotnet-bundle

The supplied workflow requires that the secrets.NOTARIZATION_USERNAME and secrets.NOTARIZATION_PASSWORD are set.

The workflow uses the following actions in order to notarize and staple:
https://github.com/devbotsxyz/xcode-notarize
and
https://github.com/devbotsxyz/xcode-staple

Issue:
https://github.com/unitystation/unitystation/issues/7926