### PR TITLE
upgrade to .NET 6

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
       - name: Test
         run: |
           dotnet test

--- a/UnitystationLauncher/Program.cs
+++ b/UnitystationLauncher/Program.cs
@@ -1,24 +1,22 @@
 using Avalonia;
 using Avalonia.ReactiveUI;
 
-namespace UnitystationLauncher
+namespace UnitystationLauncher;
+static class Program
 {
-    static class Program
-    {
-        public static void Main(string[] args) => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args) => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
 
-        // Avalonia configuration, don't remove; also used by visual designer.
-        public static AppBuilder BuildAvaloniaApp()
-            => AppBuilder.Configure<App>()
-                .UsePlatformDetect()
-                .With(new X11PlatformOptions { UseGpu = true })
-                .With(new AvaloniaNativePlatformOptions { UseGpu = true, UseDeferredRendering = false })
-                .With(new MacOSPlatformOptions { ShowInDock = true })
-                .With(new Win32PlatformOptions
-                {
-                    UseDeferredRendering = false
-                })
-                .LogToTrace()
-                .UseReactiveUI();
-    }
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .With(new X11PlatformOptions { UseGpu = true })
+            .With(new AvaloniaNativePlatformOptions { UseGpu = true, UseDeferredRendering = false })
+            .With(new MacOSPlatformOptions { ShowInDock = true })
+            .With(new Win32PlatformOptions
+            {
+                UseDeferredRendering = false
+            })
+            .LogToTrace()
+            .UseReactiveUI();
 }

--- a/UnitystationLauncher/UnitystationLauncher.csproj
+++ b/UnitystationLauncher/UnitystationLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release</Configurations>

--- a/UnitystationLauncher/UnitystationLauncher.csproj
+++ b/UnitystationLauncher/UnitystationLauncher.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
     <Nullable>enable</Nullable>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.0",
-    "rollForward": "latestMajor",
-    "allowPrerelease": true
-  }
-}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
title

.NET 3 is out of service and no longer receives security updates, moving to the latest version avoids security issues.