### PR TITLE
Fix the build action failing due to the format check

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,9 +7,34 @@ on:
   pull_request:
     branches:
       - "*"
+  workflow_dispatch:
+    branches:
+      - "develop"
+
+env:
+  DOTNET_VERSION: '6.0.x'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Format check
+        run: |
+          dotnet format --verify-no-changes
+
+      - name: Test
+        run: |
+          dotnet test
+
   build:
+    needs: [ test ] # Fail fast if format or tests fail
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,7 +48,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Test
         run: |
           dotnet test
@@ -50,24 +75,3 @@ jobs:
         with:
           name: StationHub-${{ matrix.target-platform }}
           path: ~/publish
-
-  format:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Add dotnet-format problem matcher
-        uses: xt0rted/dotnet-format-problem-matcher@v1
-
-      - name: Restore dotnet tools
-        uses: xt0rted/dotnet-tool-restore@v1
-
-      - name: Run dotnet format
-        uses: jfversluis/dotnet-format@v1.0.9
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          action: check
-          only-changed-files: true
-          workspace: "UnitystationLauncher.sln"

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -34,7 +34,6 @@ jobs:
           dotnet test
 
   build:
-    needs: [ test ] # Fail fast if format or tests fail
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,14 +43,14 @@ jobs:
           - "osx-x64"
 
     steps:
-      - uses: actions/checkout@v1
+      # Setup
+      - uses: actions/checkout@v3
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-      - name: Test
-        run: |
-          dotnet test
+
+      # Build
       - name: Publish MacOS
         if: ${{ contains(matrix.target-platform, 'osx-x64' )}}
         run: |
@@ -63,15 +62,17 @@ jobs:
         if: ${{ !contains(matrix.target-platform, 'osx-x64' )}}
         run: |
           dotnet publish --configuration Release --runtime ${{ matrix.target-platform }} --output ~/publish
+
+      # Upload
       - name: Upload MacOS Build
         if: ${{ contains(matrix.target-platform, 'osx-x64' )}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: StationHub-${{ matrix.target-platform }}
           path: ~/publish/StationHub.tar
       - name: Upload Build
         if: ${{ !contains(matrix.target-platform, 'osx-x64' )}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: StationHub-${{ matrix.target-platform }}
           path: ~/publish

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches:
       - "*"
-  workflow_dispatch:
-    branches:
-      - "develop"
 
 env:
   DOTNET_VERSION: '6.0.x'

--- a/UnitystationLauncher/Services/ServerService.cs
+++ b/UnitystationLauncher/Services/ServerService.cs
@@ -44,7 +44,7 @@ namespace UnitystationLauncher.Services
             Log.Information("Server list fetched");
 
             var servers = new List<Server>();
-            if(serverData != null)
+            if (serverData != null)
             {
                 foreach (var server in serverData)
                 {


### PR DESCRIPTION
The format `--check` command line option was renamed to `--verify-no-changes`, so the action fails when trying to run. Looking at the referenced 3rd-party actions that were being used for this it seems they were never updated to account for that change.

This PR changes:
- Replaces that referenced action with just a `dotnet format --verify-no-changes` command.
- Moves `dotnet test` to a different job so it only needs to run once, should speed up build times a bit.
- Updates the versions of the referenced actions to the latest available.
- Fixes one small formatting issue that was reported so the build is in a passing state.