### PR TITLE
Add missing using statements for flatpak build

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -51,14 +51,14 @@ jobs:
       - name: Publish MacOS
         if: ${{ contains(matrix.target-platform, 'osx-x64' )}}
         run: |
-          dotnet publish --configuration Release --runtime ${{ matrix.target-platform }} -t:BundleApp -p:RuntimeIdentifier=${{ matrix.target-platform }} -p:UseAppHost=true --output ~/publish \
+          dotnet publish --configuration Release --runtime ${{ matrix.target-platform }} -t:BundleApp -p:RuntimeIdentifier=${{ matrix.target-platform }} -p:UseAppHost=true --property PublishDir=~/publish \
           && sudo chmod +x ~/publish/StationHub.app/Contents/MacOS/StationHub \
           && cd ~/publish \
           && tar -cvf ~/publish/StationHub.tar StationHub.app
       - name: Publish
         if: ${{ !contains(matrix.target-platform, 'osx-x64' )}}
         run: |
-          dotnet publish --configuration Release --runtime ${{ matrix.target-platform }} --output ~/publish
+          dotnet publish --configuration Release --runtime ${{ matrix.target-platform }} --property PublishDir=~/publish
 
       # Upload
       - name: Upload MacOS Build

--- a/UnitystationLauncher/ViewModels/ServerViewModel.cs
+++ b/UnitystationLauncher/ViewModels/ServerViewModel.cs
@@ -11,6 +11,8 @@ using UnitystationLauncher.Models.Api;
 using UnitystationLauncher.Services;
 
 #if FLATPAK
+using System.Diagnostics;
+using System.IO;
 using System.Text.RegularExpressions;
 #endif
 


### PR DESCRIPTION
Build was failing when defining FLATPAK in the build due to these two missing using statements.

For reference:
```
dotnet build /p:DefineConstants="FLATPAK"
```

This should probably be added as part of the PR build action so this doesn't happen.