### PR TITLE
Fix invalid metainfo and update executable in the .desktop entry

### DIFF
--- a/UnitystationLauncher/Assets/org.unitystation.StationHub.desktop
+++ b/UnitystationLauncher/Assets/org.unitystation.StationHub.desktop
@@ -3,13 +3,7 @@
 [Desktop Entry]
 Name=StationHub
 Comment=Connect to Unitystation servers & manage your installs
-#Note to packagers: Write a simple .sh running
-# 1. A dotnet binary you know is available with the argument
-# 2. The path to stationhub.dll
-# And then place somewhere appropriate in the path
-Exec=stationhub.sh
+Exec=StationHub
 Type=Application
-#Rename the Icon according to freedesktop standards. 
-#The provided icons are named "Ian" to not break from non-linux targets
 Icon=org.unitystation.StationHub
 Categories=Game

--- a/UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml
+++ b/UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml
@@ -47,15 +47,15 @@
 </screenshots>
 
 <releases>
-	<release version="927" date="2020-02-16">
-		<description>
-			<p>Stationhub is now under the MIT license. Pinging in sandbox has been fixed.</p>
-		</description>
-	</release>
 	<release version="930" date="2021-11-30">
 		<description>
 			<p>Added server validation logic that will hide servers who don't host their downloads in our CDN for security purposes.</p>
 			<p>StationHub got a face lifting with some first iterations of future features!.</p>
+		</description>
+	</release>
+	<release version="927" date="2020-02-16">
+		<description>
+			<p>Stationhub is now under the MIT license. Pinging in sandbox has been fixed.</p>
 		</description>
 	</release>
 </releases>


### PR DESCRIPTION
The Flatpak should be able to be build as a self-contained app, so we don't need this shell script to launch it anymore.
The release notes in the metainfo also needs to be in order from newest to oldest or flathub build server will reject it.