### PR TITLE
Don't crash if auth settings can't be deserialized

### DIFF
--- a/UnitystationLauncher/Services/AuthService.cs
+++ b/UnitystationLauncher/Services/AuthService.cs
@@ -32,9 +32,10 @@ namespace UnitystationLauncher.Services
 
         public string? Uid => AuthLink?.User.LocalId;
 
-        private string AuthSettingsPath = Path.Combine(Config.RootFolder, "authSettings.json");
+        private readonly string AuthSettingsPath = Path.Combine(Config.RootFolder, "authSettings.json");
 
-        private void ConvertToNewAuthFileName() {
+        private void ConvertToNewAuthFileName()
+        {
             string oldAuthSettingsPath = Path.Combine(Config.RootFolder, "settings.json");
             if (File.Exists(oldAuthSettingsPath))
             {
@@ -42,8 +43,10 @@ namespace UnitystationLauncher.Services
             }
         }
 
-        private void LoadAuthSettings() {
-            try {
+        private void LoadAuthSettings()
+        {
+            try
+            {
                 ConvertToNewAuthFileName();
 
                 if (File.Exists(AuthSettingsPath))
@@ -58,7 +61,7 @@ namespace UnitystationLauncher.Services
                 // Something went wrong reading the auth settings. Just ask the user to log in again.
                 // The auth settings file will get overwritten after they do so we don't need to clean it up.
             }
-            
+
         }
 
         public void SaveAuthSettings()
@@ -218,7 +221,7 @@ namespace UnitystationLauncher.Services
         }
     }
 
-    
+
 
     public class LoginMsg
     {

--- a/UnitystationLauncher/Services/AuthService.cs
+++ b/UnitystationLauncher/Services/AuthService.cs
@@ -23,12 +23,8 @@ namespace UnitystationLauncher.Services
         {
             _authProvider = authProvider;
             _http = http;
-            if (File.Exists(Path.Combine(Config.RootFolder, "settings.json")))
-            {
-                var json = File.ReadAllText(Path.Combine(Config.RootFolder, "settings.json"));
-                var authLink = JsonSerializer.Deserialize<FirebaseAuthLink>(json);
-                AuthLink = authLink;
-            }
+
+            LoadAuthSettings();
         }
 
         public FirebaseAuthLink? AuthLink { get; set; }
@@ -36,11 +32,40 @@ namespace UnitystationLauncher.Services
 
         public string? Uid => AuthLink?.User.LocalId;
 
-        public void Store()
+        private string AuthSettingsPath = Path.Combine(Config.RootFolder, "authSettings.json");
+
+        private void ConvertToNewAuthFileName() {
+            string oldAuthSettingsPath = Path.Combine(Config.RootFolder, "settings.json");
+            if (File.Exists(oldAuthSettingsPath))
+            {
+                File.Move(oldAuthSettingsPath, AuthSettingsPath);
+            }
+        }
+
+        private void LoadAuthSettings() {
+            try {
+                ConvertToNewAuthFileName();
+
+                if (File.Exists(AuthSettingsPath))
+                {
+                    var json = File.ReadAllText(AuthSettingsPath);
+                    var authLink = JsonSerializer.Deserialize<FirebaseAuthLink>(json);
+                    AuthLink = authLink;
+                }
+            }
+            catch (Exception)
+            {
+                // Something went wrong reading the auth settings. Just ask the user to log in again.
+                // The auth settings file will get overwritten after they do so we don't need to clean it up.
+            }
+            
+        }
+
+        public void SaveAuthSettings()
         {
             var json = JsonSerializer.Serialize(AuthLink);
 
-            using (StreamWriter writer = File.CreateText(Path.Combine(Config.RootFolder, "settings.json")))
+            using (StreamWriter writer = File.CreateText(AuthSettingsPath))
             {
                 writer.WriteLine(json);
             }
@@ -192,6 +217,8 @@ namespace UnitystationLauncher.Services
             AuthLink = null;
         }
     }
+
+    
 
     public class LoginMsg
     {

--- a/UnitystationLauncher/ViewModels/LoginStatusViewModel.cs
+++ b/UnitystationLauncher/ViewModels/LoginStatusViewModel.cs
@@ -139,7 +139,7 @@ namespace UnitystationLauncher.ViewModels
                 return;
             }
 
-            _authService.Store();
+            _authService.SaveAuthSettings();
 
             Observable.Start(() => { }).InvokeCommand(this, vm => vm.OpenLauncher);
         }

--- a/UnitystationLauncher/ViewModels/MainWindowViewModel.cs
+++ b/UnitystationLauncher/ViewModels/MainWindowViewModel.cs
@@ -133,7 +133,7 @@ namespace UnitystationLauncher.ViewModels
                 return;
             }
             _authService.AttemptingAutoLogin = false;
-            _authService.Store();
+            _authService.SaveAuthSettings();
             Content = _launcherVm.Value;
         }
 


### PR DESCRIPTION
Should resolve the crash from https://github.com/unitystation/stationhub/pull/172#issuecomment-1449437775

The Flatpak is currently using build 927, and it looks like the auth settings from that version do not deserialize nicely in the current version. This should allow the client to still launch, the user will just have to log in again which will overwrite those invalid values.

Also just renamed the auth settings file to authSettings.json to be more clear that this is all it is used for. There is a method there to automatically translate that old settings.json over so it shouldn't be an issue. After a couple release cycles it should be safe to delete that extra method, just there so it doesn't immediately force everyone to log in again.