### PR TITLE
Remove auto update

### DIFF
--- a/UnitystationLauncher/Constants/LinkUrls.cs
+++ b/UnitystationLauncher/Constants/LinkUrls.cs
@@ -1,0 +1,11 @@
+namespace UnitystationLauncher.Constants;
+
+public static class LinkUrls
+{
+    public const string MainSiteUrl = "https://unitystation.org";
+    public const string PatreonUrl = "https://www.patreon.com/unitystation";
+    public const string GameIssuesUrl = "https://github.com/unitystation/unitystation/issues";
+    public const string LauncherIssuesUrl = "https://github.com/unitystation/stationhub/issues";
+    public const string DiscordInviteUrl = "https://discord.com/invite/tFcTpBp";
+    public const string LauncherReleasesUrl = "https://github.com/unitystation/stationhub/releases";
+}

--- a/UnitystationLauncher/Models/ConfigFile/Config.cs
+++ b/UnitystationLauncher/Models/ConfigFile/Config.cs
@@ -20,13 +20,6 @@ namespace UnitystationLauncher.Models.ConfigFile
         private const string UnixExeName = "StationHub";
         private const string InstallationFolder = "Installations";
 
-        // Other URLs
-        public const string MainSiteUrl = "https://unitystation.org";
-        public const string PatreonUrl = "https://www.patreon.com/unitystation";
-        public const string GameIssuesUrl = "https://github.com/unitystation/unitystation/issues";
-        public const string LauncherIssuesUrl = "https://github.com/unitystation/stationhub/issues";
-        public const string DiscordInviteUrl = "https://discord.com/invite/tFcTpBp";
-
         private HubClientConfig? _hubClientConfig;
         private readonly HttpClient _http;
         private Preferences? _preferences;

--- a/UnitystationLauncher/Models/ConfigFile/Preferences.cs
+++ b/UnitystationLauncher/Models/ConfigFile/Preferences.cs
@@ -6,7 +6,7 @@ namespace UnitystationLauncher.Models.ConfigFile
     {
         private bool _autoRemove = true;
         private string? _lastLogin = "";
-        private int _ignoreVersionUpdate = 0;
+        private int _ignoreVersionUpdate;
 
         public bool AutoRemove
         {

--- a/UnitystationLauncher/Models/ConfigFile/Preferences.cs
+++ b/UnitystationLauncher/Models/ConfigFile/Preferences.cs
@@ -6,6 +6,7 @@ namespace UnitystationLauncher.Models.ConfigFile
     {
         private bool _autoRemove = true;
         private string? _lastLogin = "";
+        private int _ignoreVersionUpdate = 0;
 
         public bool AutoRemove
         {
@@ -17,6 +18,12 @@ namespace UnitystationLauncher.Models.ConfigFile
         {
             get => _lastLogin;
             set => this.RaiseAndSetIfChanged(ref _lastLogin, value);
+        }
+
+        public int IgnoreVersionUpdate
+        {
+            get => _ignoreVersionUpdate;
+            set => this.RaiseAndSetIfChanged(ref _ignoreVersionUpdate, value);
         }
     }
 }

--- a/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
+++ b/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
@@ -1,24 +1,10 @@
-﻿using Avalonia;
-using Avalonia.Controls.ApplicationLifetimes;
-using ReactiveUI;
-using Serilog;
+﻿using ReactiveUI;
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
-using System.Net.Http;
 using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Humanizer;
-using Mono.Unix;
 using UnitystationLauncher.Constants;
-using UnitystationLauncher.Exceptions;
-using UnitystationLauncher.Infrastructure;
 using UnitystationLauncher.Models.ConfigFile;
 
 namespace UnitystationLauncher.ViewModels

--- a/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
+++ b/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Humanizer;
 using Mono.Unix;
+using UnitystationLauncher.Constants;
 using UnitystationLauncher.Exceptions;
 using UnitystationLauncher.Infrastructure;
 using UnitystationLauncher.Models.ConfigFile;
@@ -24,63 +25,6 @@ namespace UnitystationLauncher.ViewModels
 {
     public class HubUpdateViewModel : ViewModelBase, IDisposable
     {
-        private CancellationTokenSource? _cancelSource;
-        private readonly Lazy<LoginViewModel> _loginVm;
-        private readonly Config _config;
-        private string? _updateTitle;
-        private string? _updateMessage;
-        private string? _buttonMessage;
-        private string? _downloadMessage;
-        private bool _installButtonVisible;
-        private bool _downloadBarVisible;
-        private bool _restartButtonVisible;
-        private readonly Process _thisProcess;
-        private readonly HttpClient _http;
-
-        public HubUpdateViewModel(Lazy<LoginViewModel> loginVm, Config config, HttpClient http)
-        {
-            _loginVm = loginVm;
-            _config = config;
-            _http = http;
-            BeginDownload = ReactiveCommand.CreateFromTask(UpdateHubAsync);
-            RestartHub = ReactiveCommand.Create(RestartApp);
-            Cancel = ReactiveCommand.Create(CancelInstall);
-
-            UpdateTitle = "Update Required";
-            UpdateMessage = $"An update is required before you can continue.\n\rPlease install" +
-                            $" the latest version by clicking the button below:";
-
-            ButtonMessage = $"Update Hub";
-            _thisProcess = Process.GetCurrentProcess();
-
-            InstallButtonVisible = true;
-            DownloadBarVisible = false;
-            RestartButtonVisible = false;
-        }
-
-        public ReactiveCommand<Unit, Unit> BeginDownload { get; }
-        public ReactiveCommand<Unit, Unit> RestartHub { get; }
-        public ReactiveCommand<Unit, ViewModelBase> Cancel { get; }
-        public Subject<int> Progress { get; set; } = new Subject<int>();
-
-        public bool InstallButtonVisible
-        {
-            get => _installButtonVisible;
-            set => this.RaiseAndSetIfChanged(ref _installButtonVisible, value);
-        }
-
-        public bool DownloadBarVisible
-        {
-            get => _downloadBarVisible;
-            set => this.RaiseAndSetIfChanged(ref _downloadBarVisible, value);
-        }
-
-        public bool RestartButtonVisible
-        {
-            get => _restartButtonVisible;
-            set => this.RaiseAndSetIfChanged(ref _restartButtonVisible, value);
-        }
-
         public string? UpdateTitle
         {
             get => _updateTitle;
@@ -93,202 +37,73 @@ namespace UnitystationLauncher.ViewModels
             set => this.RaiseAndSetIfChanged(ref _updateMessage, value);
         }
 
-        public string? ButtonMessage
+        public ReactiveCommand<Unit, LauncherViewModel> Skip { get; }
+        public ReactiveCommand<Unit, LauncherViewModel> Ignore { get; }
+
+        private readonly Lazy<LauncherViewModel> _launcherVm;
+        private readonly Config _config;
+        private string? _updateTitle;
+        private string? _updateMessage;
+        private readonly Process _thisProcess;
+        private readonly int _newVersion;
+
+        public HubUpdateViewModel(Lazy<LauncherViewModel> launcherVm, Config config)
         {
-            get => _buttonMessage;
-            set => this.RaiseAndSetIfChanged(ref _buttonMessage, value);
+            _launcherVm = launcherVm;
+            _config = config;
+            Ignore = ReactiveCommand.CreateFromTask(IgnoreUpdate);
+            Skip = ReactiveCommand.Create(SkipUpdate);
+
+            UpdateTitle = "Launcher Update Available";
+
+            _newVersion = GetUpdateVersion().Result;
+
+            UpdateMessage = $"Launcher version {_newVersion} is available.\n"
+                            + $"Current version: {Config.CurrentBuild}";
+            _thisProcess = Process.GetCurrentProcess();
         }
 
-        public string? DownloadMessage
+        private async Task<int> GetUpdateVersion()
         {
-            get => _downloadMessage;
-            set => this.RaiseAndSetIfChanged(ref _downloadMessage, value);
-        }
-
-        public async Task UpdateHubAsync()
-        {
-            try
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
-                    RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    GiveAllOwnerPermissions(Config.UnixExeFullPath);
-                }
-
-                _cancelSource = new CancellationTokenSource();
-                await TryUpdateAsync(_cancelSource.Token);
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Failed to update hub");
-            }
-        }
-
-        private async Task TryUpdateAsync(CancellationToken cancelToken)
-        {
-            Directory.CreateDirectory(Config.TempFolder);
-
-            GiveAllOwnerPermissions(Config.TempFolder);
-
-            InstallButtonVisible = false;
-            DownloadBarVisible = true;
-            UpdateTitle = "Downloading...";
-
-            Log.Information("Download started...");
             HubClientConfig? hubClientConfig = await _config.GetServerHubClientConfigAsync();
-
-            if (hubClientConfig == null)
-            {
-                Log.Error("Error: {Error}", "Unable to retrieve client config from hub.");
-                return;
-            }
-
-            string? downloadUrl = hubClientConfig.GetDownloadUrl();
-            if (downloadUrl == null)
-            {
-                Log.Error("DownloadUrl is null");
-                return;
-            }
-
-            Log.Information("Download started...");
-            var request = await _http.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead, cancelToken);
-            await using Stream responseStream = await request.Content.ReadAsStreamAsync(cancelToken);
-
-            Log.Information("Download connection established");
-            await using var progStream = new ProgressStream(responseStream);
-            var length = request.Content.Headers.ContentLength ??
-                         throw new ContentLengthNullException(downloadUrl);
-
-            progStream.Progress
-                .Select(p => (int)(p * 100 / length))
-                .DistinctUntilChanged()
-                .Subscribe(p => { Progress.OnNext(p); });
-
-            var lastPosition = 0L;
-            var lastTime = DateTime.Now;
-            using var progStreamDisposable = progStream.Progress
-                .Subscribe(pos =>
-                {
-                    var time = DateTime.Now;
-                    var deltaPos = pos - lastPosition;
-                    var deltaTime = time - lastTime;
-                    var deltaPercentage = deltaPos * 100 / length;
-                    var percentage = pos * 100 / length;
-
-                    if (pos != length)
-                    {
-                        if (deltaPercentage < 5 && deltaTime.TotalSeconds < .1)
-                        {
-                            return;
-                        }
-                    }
-
-                    var speed = deltaPos.Bytes().Per(deltaTime);
-                    var downloaded = pos.Bytes();
-                    var totalDownload = length.Bytes();
-                    DownloadMessage = $"{downloaded.ToString("#.#")} / {totalDownload.ToString("#.#")}";
-                    Log.Information("Progress: {ProgressPercent}%, Speed = {DownloadSpeed}",
-                        percentage,
-                        speed.Humanize("#.##"));
-
-                    lastPosition = pos;
-                    lastTime = time;
-                });
-
-            await Task.Run(() =>
-            {
-                Log.Information("Extracting...");
-                try
-                {
-                    var archive = new ZipArchive(progStream);
-                    // TODO: Enable extraction cancelling
-                    archive.ExtractToDirectory(Config.TempFolder, true);
-
-                    Log.Information("Download completed");
-                }
-                catch
-                {
-                    Log.Information("Extracting stopped");
-                }
-            }, cancelToken);
-
-            DownloadComplete();
+            return hubClientConfig?.BuildNumber ?? 0;
         }
 
-        private void DownloadComplete()
+        private void Update()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            ProcessStartInfo psi = new()
             {
-                GiveAllOwnerPermissions(Config.TempFolder);
-            }
+                FileName = LinkUrls.LauncherReleasesUrl,
+                UseShellExecute = true
+            };
 
-            DownloadBarVisible = false;
-            RestartApp();
+            Process.Start(psi);
+
+            // Need to just wait a small amount of time, otherwise we will exit before that is finished opening
+            Thread.Sleep(100);
+
+            Exit();
         }
 
-        private void OnExit(object? sender, EventArgs e)
+        private void Exit()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                string argument = "-c \" sleep 1; cp -a {0}/. {1}; rm -rf {0}; {2}";
-
-                ProcessStartInfo info = new ProcessStartInfo();
-                info.Arguments = string.Format(
-                    argument,
-                    Regex.Escape(Config.TempFolder),
-                    Regex.Escape(Config.RootFolder),
-                    Regex.Escape(Config.UnixExeFullPath));
-                info.WindowStyle = ProcessWindowStyle.Hidden;
-                info.CreateNoWindow = true;
-                info.FileName = "/bin/bash";
-                Process.Start(info);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                string argument =
-                    "/C echo \"{2}\" & Choice /C Y /N /D Y /T 1 & xcopy /Y \"{0}\" \"{1}\" & rmdir /q /s \"{0}\" & echo \"{3}\" & \"{4}\"";
-                ProcessStartInfo info = new ProcessStartInfo();
-                info.Arguments = string.Format(argument, Config.TempFolder, Config.RootFolder,
-                    "Updating hub please wait..", "Update complete.", Config.WinExeFullPath);
-                info.WindowStyle = ProcessWindowStyle.Normal;
-                info.UseShellExecute = false;
-                info.FileName = "cmd";
-                Process.Start(info);
-            }
-
             _thisProcess.Kill();
         }
 
-        ViewModelBase CancelInstall()
+        private LauncherViewModel SkipUpdate()
         {
-            _cancelSource?.Cancel();
-            return _loginVm.Value;
+            return _launcherVm.Value;
         }
 
-        void RestartApp()
+        private async Task<LauncherViewModel> IgnoreUpdate()
         {
-            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
-            {
-                desktopLifetime.Exit += OnExit;
-                desktopLifetime.Shutdown();
-            }
-        }
-
-        private void GiveAllOwnerPermissions(string path)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return;
-            }
-
-            new UnixFileInfo(path).FileAccessPermissions |= FileAccessPermissions.UserReadWriteExecute;
+            Preferences preferences = await _config.GetPreferencesAsync();
+            preferences.IgnoreVersionUpdate = _newVersion;
+            return _launcherVm.Value;
         }
 
         public void Dispose()
         {
-            _cancelSource?.Dispose();
             _thisProcess.Dispose();
         }
     }

--- a/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
+++ b/UnitystationLauncher/ViewModels/HubUpdateViewModel.cs
@@ -66,7 +66,8 @@ namespace UnitystationLauncher.ViewModels
             Process.Start(psi);
 
             // Need to just wait a small amount of time, otherwise we will exit before that is finished opening
-            Thread.Sleep(100);
+            const int millisecondsToWait = 100;
+            Thread.Sleep(millisecondsToWait);
 
             Exit();
         }

--- a/UnitystationLauncher/ViewModels/LauncherViewModel.cs
+++ b/UnitystationLauncher/ViewModels/LauncherViewModel.cs
@@ -57,7 +57,7 @@ namespace UnitystationLauncher.ViewModels
             ShowUpdateView = ReactiveCommand.Create(ShowUpdateImp);
             SelectedPanel = serversPanel;
 
-            RxApp.MainThreadScheduler.ScheduleAsync((_, _) => ValidateClientVersionAsync(config));
+            RxApp.MainThreadScheduler.ScheduleAsync((_, _) => ValidateClientVersionAsync());
         }
 
         private PanelBase[] GetEnabledPanels(
@@ -91,7 +91,7 @@ namespace UnitystationLauncher.ViewModels
             return panelBases.ToArray();
         }
 
-        private async Task ValidateClientVersionAsync(Config config)
+        private async Task ValidateClientVersionAsync()
         {
             HubClientConfig? hubClientConfig = await _config.GetServerHubClientConfigAsync();
 
@@ -107,7 +107,7 @@ namespace UnitystationLauncher.ViewModels
                     Config.CurrentBuild,
                     hubClientConfig.BuildNumber);
 
-                Preferences preferences = await config.GetPreferencesAsync();
+                Preferences preferences = await _config.GetPreferencesAsync();
 
                 if (preferences.IgnoreVersionUpdate < hubClientConfig.BuildNumber)
                 {

--- a/UnitystationLauncher/ViewModels/MainWindowViewModel.cs
+++ b/UnitystationLauncher/ViewModels/MainWindowViewModel.cs
@@ -34,8 +34,6 @@ namespace UnitystationLauncher.ViewModels
             set => this.RaiseAndSetIfChanged(ref _maximizeToolTip, value);
         }
 
-        public ReactiveCommand<Unit, Unit> CommandMaximizee { get; }
-
         public MainWindowViewModel(LoginViewModel loginVm, Lazy<LoginStatusViewModel> loginStatusVm, Lazy<LauncherViewModel> launcherVm,
             AuthService authService)
         {
@@ -47,8 +45,7 @@ namespace UnitystationLauncher.ViewModels
             authService.AttemptingAutoLogin = false;
             _maximizeIcon = Geometry.Parse("M2048 2048v-2048h-2048v2048h2048zM1843 1843h-1638v-1638h1638v1638z");
             _maximizeToolTip = "Maximize";
-            CommandMaximizee = ReactiveCommand.Create(Maximize);
-            RxApp.MainThreadScheduler.ScheduleAsync((scheduler, ct) => CheckForExistingUserAsync());
+            RxApp.MainThreadScheduler.ScheduleAsync((_, _) => CheckForExistingUserAsync());
         }
 
         private void Maximize()
@@ -152,14 +149,15 @@ namespace UnitystationLauncher.ViewModels
 
                 LauncherViewModel launcherVm => Observable.Merge(
                     launcherVm.Logout.Select(vm => (ViewModelBase)vm),
-                    launcherVm.ShowUpdateReqd.Select(vm => (ViewModelBase)vm)),
+                    launcherVm.ShowUpdateView.Select(vm => (ViewModelBase)vm)),
 
                 SignUpViewModel signUpViewModel => Observable.Merge(
                     signUpViewModel.Cancel,
                     signUpViewModel.DoneButton),
 
                 HubUpdateViewModel hubUpdateViewModel => Observable.Merge(
-                    hubUpdateViewModel.Cancel),
+                    hubUpdateViewModel.Skip,
+                    hubUpdateViewModel.Ignore),
 
                 ForgotPasswordViewModel forgotPasswordViewModel => Observable.Merge(
                     forgotPasswordViewModel.DoneButton),

--- a/UnitystationLauncher/ViewModels/NewsPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/NewsPanelViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Media.Imaging;
 using System;
 using System.Reactive;
 using System.Diagnostics;
+using UnitystationLauncher.Constants;
 using UnitystationLauncher.Models.ConfigFile;
 
 namespace UnitystationLauncher.ViewModels
@@ -41,11 +42,11 @@ namespace UnitystationLauncher.ViewModels
         {
             _changelog = changelog;
 
-            OpenMainSite = ReactiveCommand.Create(() => OpenLink(Config.MainSiteUrl));
-            OpenPatreon = ReactiveCommand.Create(() => OpenLink(Config.PatreonUrl));
-            OpenGameIssues = ReactiveCommand.Create(() => OpenLink(Config.GameIssuesUrl));
-            OpenLauncherIssues = ReactiveCommand.Create(() => OpenLink(Config.LauncherIssuesUrl));
-            OpenDiscordInvite = ReactiveCommand.Create(() => OpenLink(Config.DiscordInviteUrl));
+            OpenMainSite = ReactiveCommand.Create(() => OpenLink(LinkUrls.MainSiteUrl));
+            OpenPatreon = ReactiveCommand.Create(() => OpenLink(LinkUrls.PatreonUrl));
+            OpenGameIssues = ReactiveCommand.Create(() => OpenLink(LinkUrls.GameIssuesUrl));
+            OpenLauncherIssues = ReactiveCommand.Create(() => OpenLink(LinkUrls.LauncherIssuesUrl));
+            OpenDiscordInvite = ReactiveCommand.Create(() => OpenLink(LinkUrls.DiscordInviteUrl));
 
             var assets = AvaloniaLocator.Current.GetService<IAssetLoader>();
             _backGroundImage = new Bitmap(assets?.Open(new Uri("avares://StationHub/Assets/bgnews.png")));

--- a/UnitystationLauncher/Views/HubUpdateView.xaml
+++ b/UnitystationLauncher/Views/HubUpdateView.xaml
@@ -15,31 +15,18 @@
         <Border BorderThickness="1" BorderBrush="#c5c5c5" />
 
         <StackPanel>
-            <TextBlock TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10"
-                       Text="{Binding UpdateTitle}" />
-            <TextBlock TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="14"
-                       Margin="10"
-                       Text="{Binding UpdateMessage}" IsVisible="{Binding InstallButtonVisible}" />
-            <!--Downloading bar-->
-            <StackPanel DockPanel.Dock="Top" HorizontalAlignment="Center" IsVisible="{Binding DownloadBarVisible}">
-                <Viewbox Margin="30 0 30 5" MaxHeight="25">
-                    <ProgressBar Value="{Binding Progress^}" Background="#353F4F" />
-                </Viewbox>
-                <TextBlock Text="{Binding DownloadMessage}" HorizontalAlignment="Center" FontSize="14" />
-            </StackPanel>
-
-            <Button Command="{Binding BeginDownload}" Padding="5" Margin="10"
-                    HorizontalAlignment="Center" MinWidth="100"
-                    Content="{Binding ButtonMessage}" IsVisible="{Binding InstallButtonVisible}" Classes="SmallButton"
-                    FontSize="15" />
-            <Button Command="{Binding Cancel}" Padding="5" Margin="10"
-                    HorizontalAlignment="Center" MinWidth="100"
-                    Content="Cancel" IsVisible="{Binding DownloadBarVisible}" Classes="SmallButton" />
-            <Button Command="{Binding RestartHub}" Padding="5" Margin="10"
-                    HorizontalAlignment="Center" MinWidth="100"
-                    Content="Restart" IsVisible="{Binding RestartButtonVisible}" Classes="SmallButton" />
+            <TextBlock TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10" Text="{Binding UpdateTitle}" />
+            <TextBlock TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="14" Margin="10" Text="{Binding UpdateMessage}" />
+            
+            <WrapPanel HorizontalAlignment="Center">
+                <Button Command="{Binding Update}" Classes="SmallButton" Padding="5" Margin="5" MinWidth="100" Content="Update" />
+                <Button Command="{Binding Skip}" Classes="SmallButton" Padding="5" Margin="5" MinWidth="100" Content="Skip" />
+            </WrapPanel>
+            
+            <Button Command="{Binding Ignore}" Classes="SmallButton" Padding="5" Margin="10"
+                    MinWidth="175" HorizontalAlignment="Center" Content="Ignore Update" />
+            
         </StackPanel>
         <Border BorderThickness="1" BorderBrush="#c5c5c5" />
     </StackPanel>
-
 </UserControl>


### PR DESCRIPTION
Removes auto update option and instead prompts the user to update manually. Also with the number of links, I figured its probably good to move them to their own class instead of the config.

Options are:
- Update
  - Opens the releases page of StationHub and closes the program.
- Skip
  - Skips the update, will prompt again on next launch.
- Ignore Update
  - Skips the update, will not prompt again until another new version is released.

Screenshot of prompt screen:
![Screenshot from 2023-03-05 22-44-31](https://user-images.githubusercontent.com/5573038/223027302-ac28ac83-0838-44c3-ad84-3ab052252d5c.png)

Video of functionality:

https://user-images.githubusercontent.com/5573038/223027445-8cececea-f1ea-401a-bee6-74357432059d.mp4

Fixes #138
Fixes #137