### PR TITLE
Fix server list being dropped when invalid ip is provided by a single server

### DIFF
--- a/UnitystationLauncher/Models/Api/Server.cs
+++ b/UnitystationLauncher/Models/Api/Server.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using System.Runtime.InteropServices;
 using UnitystationLauncher.Models.ConfigFile;
 
@@ -56,6 +57,10 @@ namespace UnitystationLauncher.Models.Api
                 return true;
             }
         }
+
+        public bool HasValidDomainName => Uri.CheckHostName(ServerIp) == UriHostNameType.Dns;
+
+        public bool HasValidIpAddress => IPAddress.TryParse(ServerIp, out _);
 
         public string InstallationName => ForkName + BuildVersion;
 

--- a/UnitystationLauncher/Models/Installation.cs
+++ b/UnitystationLauncher/Models/Installation.cs
@@ -6,7 +6,6 @@ using Serilog;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -55,12 +54,12 @@ namespace UnitystationLauncher.Models
             return exe;
         }
 
-        public void Start(IPAddress ip, short port, string? refreshToken, string? uid)
+        public void LaunchWithArgs(string ip, short port, string? refreshToken, string? uid)
         {
             Start($"--server {ip} --port {port} --refreshtoken {refreshToken} --uid {uid}");
         }
 
-        public void Start()
+        public void LaunchWithoutArgs()
         {
             Start("");
         }

--- a/UnitystationLauncher/Services/ServerService.cs
+++ b/UnitystationLauncher/Services/ServerService.cs
@@ -8,7 +8,6 @@ using ReactiveUI;
 using Serilog;
 using UnitystationLauncher.Constants;
 using UnitystationLauncher.Models.Api;
-using UnitystationLauncher.Models.ConfigFile;
 
 namespace UnitystationLauncher.Services
 {
@@ -40,14 +39,14 @@ namespace UnitystationLauncher.Services
         {
             Refreshing = true;
 
-            var data = await _http.GetStringAsync(ApiUrls.ServerListUrl);
-            var serverData = JsonConvert.DeserializeObject<ServerList>(data)?.Servers;
+            string data = await _http.GetStringAsync(ApiUrls.ServerListUrl);
+            List<Server>? serverData = JsonConvert.DeserializeObject<ServerList>(data)?.Servers;
             Log.Information("Server list fetched");
 
-            var servers = new List<Server>();
+            List<Server> servers = new();
             if (serverData != null)
             {
-                foreach (var server in serverData)
+                foreach (Server server in serverData)
                 {
                     if (!server.HasTrustedUrlSource)
                     {

--- a/UnitystationLauncher/ViewModels/InstallationViewModel.cs
+++ b/UnitystationLauncher/ViewModels/InstallationViewModel.cs
@@ -9,7 +9,7 @@ namespace UnitystationLauncher.ViewModels
         public InstallationViewModel(Installation installation)
         {
             Installation = installation;
-            LaunchCommand = ReactiveCommand.Create(Installation.Start);
+            LaunchCommand = ReactiveCommand.Create(Installation.LaunchWithoutArgs);
             UninstallCommand = ReactiveCommand.CreateFromTask(Installation.DeleteAsync);
         }
 

--- a/UnitystationLauncher/ViewModels/ServerViewModel.cs
+++ b/UnitystationLauncher/ViewModels/ServerViewModel.cs
@@ -71,7 +71,7 @@ namespace UnitystationLauncher.ViewModels
             // If an error occurred, display the exception to the user.  
             if (eventArgs.Error != null)
             {
-                Log.Error(eventArgs.Error, "Ping failed");
+                Log.Error("Ping failed: {Error}", eventArgs.Error);
                 return;
             }
 

--- a/UnitystationLauncher/Views/ServerView.axaml
+++ b/UnitystationLauncher/Views/ServerView.axaml
@@ -36,7 +36,7 @@
                         </MultiBinding.Bindings>
                     </MultiBinding>
                 </Panel.IsVisible>
-                <Button Command="{Binding Start}" Content="Start" Background="{StaticResource PrimaryTransparent4}"
+                <Button Command="{Binding LaunchGame}" Content="Start" Background="{StaticResource PrimaryTransparent4}"
                         BorderThickness="0" />
             </Panel>
             <StackPanel IsVisible="{Binding Downloading^}" VerticalAlignment="Center">


### PR DESCRIPTION
This change should also allow you to join a server using a domain name instead of an IP address. Tested using `natsuko.ninja` for Wild Frontier FFA, and I was able to join and play without issues.

Fixes #161