### PR TITLE
Update metainfo and version number to 931

### DIFF
--- a/UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml
+++ b/UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml
@@ -6,13 +6,19 @@
 <metadata_license>CC0-1.0</metadata_license> 
 <project_license>MIT</project_license>
 <name>StationHub</name>
-<summary>Launcher for the Unitystation Space Station 13 remake</summary>
+<summary>Launcher for the open-source game Unitystation</summary>
 <developer_name>Unitystation Team</developer_name>
 
 <description>
+	<p>StationHub is a server browser and installation manager for the open-source game Unitystation.</p>
 	<p>
-		StationHub acts as a server browser and install manager for Unitystation, a multiplayer role-playing game
-		based on the classic Space Station 13
+		Based on cult classic Space Station 13, Unitystation is a multiplayer RPG about life in deep space. 
+		Be an engineer, lawyer, surgeon or clown and keep the station safe from saboteurs. 
+		Each round is filled with paranoia and lighthearted fun, even as you get thrown out the airlock.
+	</p>
+	<p>
+	  The game is full of paranoia and lighthearted shenanigans, being a station that is as much at risk from clowns and mimes as it is from undercover operatives, eldritch cultists, changelings, demons, revolutions, and assaults from enemy corporations. 
+		Played in rounds that reset the station every time, the game features an assortment of jobs, including doctors, chemists, scientists, janitors, engineers, atmospheric technicians, security guards, bartenders and the all-important clown.
 	</p>
 </description>
 
@@ -37,6 +43,14 @@
 
 <screenshots>
 	<screenshot type="default">
+		<caption>StationHub news panel</caption>
+		<image>https://unitystationfile.b-cdn.net/screenshots/stationhub2.png</image>
+	</screenshot>
+	<screenshot>
+		<caption>StationHub servers panel</caption>
+		<image>https://unitystationfile.b-cdn.net/screenshots/stationhub.png</image>
+	</screenshot>
+	<screenshot>
 		<caption>A parking accident angers an official</caption>
 		<image>https://unitystationfile.b-cdn.net/screenshots/unitystation-shuttle.png</image>
 	</screenshot>
@@ -44,9 +58,38 @@
 		<caption>A monkey god appears in the station's chapel</caption>
 		<image>https://unitystationfile.b-cdn.net/screenshots/unitystation-monke.png</image>
 	</screenshot>
+	<screenshot>
+		<caption>UI for ordering cargo from Centcomm</caption>
+		<image>https://unitystationfile.b-cdn.net/screenshots/cargo-ui.jpg</image>
+	</screenshot>
 </screenshots>
 
 <releases>
+	<release version="931" date="2023-03-13">
+		<description>
+			<p>Feature Changes:</p>
+			<ul>
+			  <li>StationHub has been upgraded to .NET 6.</li>
+				<li>Updates the changelog to come from the Changelog API instead of directly from GitHub.</li>
+				<li>Adds links to the Unitystation Discord and GitHub issues pages.</li>
+				<li>The auto update feature has been replaced with a notification.</li>
+				<li>Adds a placeholder to the News panel, this will be replaced with posts from the Unitystation Blog in the future.</li>
+			</ul>
+			<p>Bug Fixes:</p>
+			<ul>
+			  <li>Fixes a crash that would happen when your authentication token was invalid.</li>
+				<li>Fixes server list being dropped when an invalid IP address is provided.</li>
+				<li>Hides tabs that are still a work in progress and not ready to be used.</li>
+				<li>Adds a 20 second timeout to the login process.</li>
+			</ul>
+			<p>Platform Specific Changes:</p>
+			<ul>
+			  <li>[Windows] Hides the debug console from being opened.</li>
+				<li>[Windows] Installations and client settings will now be saved in your user profile's appdata directory.</li>
+				<li>[Linux Flatpak] Performance improvement when navigating to the Servers tab.</li>
+			</ul>
+		</description>
+	</release>
 	<release version="930" date="2021-11-30">
 		<description>
 			<p>Added server validation logic that will hide servers who don't host their downloads in our CDN for security purposes.</p>

--- a/UnitystationLauncher/Models/ConfigFile/Config.cs
+++ b/UnitystationLauncher/Models/ConfigFile/Config.cs
@@ -13,7 +13,7 @@ namespace UnitystationLauncher.Models.ConfigFile
     public class Config : IDisposable
     {
         //Whenever you change the currentBuild here, please also update the one in UnitystationLauncher/Assets/org.unitystation.StationHub.metainfo.xml for Linux software stores. Thank you.
-        public const int CurrentBuild = 930;
+        public const int CurrentBuild = 931;
 
         //file names
         private const string InstallationFolder = "Installations";


### PR DESCRIPTION
Updates the metainfo description to match the Steam store listing for Unitystation.
Adds a couple of new screenshots to the metainfo to show on the Flathub listing.
Changes the version number to 931 and adds the changelog to the metainfo.

Fixes #77