### PR TITLE
Add interfaces for remaining services and start unit tests

### DIFF
--- a/UnitystationLauncher.Tests/Infrastructure/TaskExtensionsTests.cs
+++ b/UnitystationLauncher.Tests/Infrastructure/TaskExtensionsTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using UnitystationLauncher.Infrastructure;
+using Xunit;
+
+namespace UnitystationLauncher.Tests.Infrastructure;
+
+public static class TaskExtensionsTests
+{
+    #region Task.AwaitWithTimeout
+    [Fact]
+    public static void AwaitWithTimeout_TimeoutsShouldThrow()
+    {
+        Func<Task> act =
+            async () => await Task.Run(InfiniteWait).AwaitWithTimeout(TimeSpan.FromMilliseconds(100), _ => { });
+
+        act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public static void AwaitWithTimeout_ActionShouldRunOnTaskCompletion()
+    {
+        Func<Task> act = async () =>
+            await Task.Run(() => Wait(100)).AwaitWithTimeout(TimeSpan.FromMilliseconds(200),
+                success =>
+                {
+                    success.Should().BeTrue();
+                });
+
+        act.Should().NotThrowAsync();
+    }
+    #endregion
+
+    private static bool Wait(int milliseconds)
+    {
+        Thread.Sleep(milliseconds);
+        return true;
+    }
+
+    private static bool InfiniteWait()
+    {
+        while (true) ;
+#pragma warning disable CS0162
+        return true;
+#pragma warning restore CS0162
+    }
+}

--- a/UnitystationLauncher.Tests/MocksRepository/MockEnvironmentService.cs
+++ b/UnitystationLauncher.Tests/MocksRepository/MockEnvironmentService.cs
@@ -1,0 +1,44 @@
+using Moq;
+using UnitystationLauncher.Models.Enums;
+using UnitystationLauncher.Services.Interface;
+
+namespace UnitystationLauncher.Tests.MocksRepository;
+
+public static class MockEnvironmentService
+{
+    public static IEnvironmentService GetLinuxStandaloneEnvironment()
+    {
+        Mock<IEnvironmentService> mock = new();
+        mock.Setup(x => x.GetCurrentEnvironment()).Returns(CurrentEnvironment.LinuxStandalone);
+        mock.Setup(x => x.GetUserdataDirectory()).Returns("/home/unitTester/UnitystationLauncher");
+        mock.Setup(x => x.ShouldDisableUpdateCheck()).Returns(false);
+        return mock.Object;
+    }
+
+    public static IEnvironmentService GetLinuxFlatpakEnvironment()
+    {
+        Mock<IEnvironmentService> mock = new();
+        mock.Setup(x => x.GetCurrentEnvironment()).Returns(CurrentEnvironment.LinuxFlatpak);
+        mock.Setup(x => x.GetUserdataDirectory()).Returns("/home/unitTester/UnitystationLauncher");
+        mock.Setup(x => x.ShouldDisableUpdateCheck()).Returns(true);
+        return mock.Object;
+    }
+
+    public static IEnvironmentService GetWindowsStandaloneEnvironment()
+    {
+        Mock<IEnvironmentService> mock = new();
+        mock.Setup(x => x.GetCurrentEnvironment()).Returns(CurrentEnvironment.WindowsStandalone);
+        mock.Setup(x => x.GetUserdataDirectory()).Returns("C:/Users/UnitTester/UnitystationLauncher");
+        mock.Setup(x => x.ShouldDisableUpdateCheck()).Returns(false);
+        return mock.Object;
+    }
+
+    public static IEnvironmentService GetMacStandaloneEnvironment()
+    {
+        Mock<IEnvironmentService> mock = new();
+        mock.Setup(x => x.GetCurrentEnvironment()).Returns(CurrentEnvironment.MacOsStandalone);
+        mock.Setup(x => x.GetUserdataDirectory()).Returns("/home/unitTester/UnitystationLauncher");
+        mock.Setup(x => x.ShouldDisableUpdateCheck()).Returns(false);
+        return mock.Object;
+    }
+}

--- a/UnitystationLauncher.Tests/Models/Api/ServerTests.cs
+++ b/UnitystationLauncher.Tests/Models/Api/ServerTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using UnitystationLauncher.Models.Api;
+using UnitystationLauncher.Tests.MocksRepository;
+using Xunit;
+
+namespace UnitystationLauncher.Tests.Models.Api;
+
+public static class ServerTests
+{
+    private const string WindowsUrl = "windows";
+    private const string MacUrl = "mac";
+    private const string LinuxUrl = "linux";
+
+    private static readonly Server _server = new("Unit Test", 0, "127.0.0.1", 0)
+    {
+        WinDownload = WindowsUrl,
+        OsxDownload = MacUrl,
+        LinuxDownload = LinuxUrl
+    };
+
+    #region Server.GetDownloadUrl
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnLinuxUrlWhenPlatformIsLinux()
+    {
+        _server.GetDownloadUrl(MockEnvironmentService.GetLinuxStandaloneEnvironment()).Should().Be(LinuxUrl);
+    }
+
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnLinuxUrlWhenPlatformIsLinuxFlatpak()
+    {
+        _server.GetDownloadUrl(MockEnvironmentService.GetLinuxFlatpakEnvironment()).Should().Be(LinuxUrl);
+    }
+
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnWindowsUrlWhenPlatformIsWindows()
+    {
+        _server.GetDownloadUrl(MockEnvironmentService.GetWindowsStandaloneEnvironment()).Should().Be(WindowsUrl);
+    }
+
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnMacUrlWhenPlatformIsMac()
+    {
+        _server.GetDownloadUrl(MockEnvironmentService.GetMacStandaloneEnvironment()).Should().Be(MacUrl);
+    }
+    #endregion
+
+    #region Server.HasTrustedUrlSource
+    [Fact]
+    public static void HasTrustedUrlSource_ShouldReturnFalseWhenNull()
+    {
+        Server server = new("Unit Test", 0, "127.0.0.1", 0)
+        {
+            WinDownload = null,
+            OsxDownload = null,
+            LinuxDownload = null
+        };
+
+        server.HasTrustedUrlSource.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("http://myshadyunitystationdownload.test")]
+    [InlineData("http://127.0.0.1")]
+    [InlineData("http://unitystationfile.b-cdn.net")]
+    [InlineData(" ")]
+    [InlineData("")]
+    public static void HasTrustedUrlSource_ShouldReturnFalseWhenUntrusted(string url)
+    {
+        Server server = new("Unit Test", 0, "127.0.0.1", 0)
+        {
+            WinDownload = $"{url}/Windows",
+            OsxDownload = $"{url}/Mac",
+            LinuxDownload = $"{url}/Linux"
+        };
+
+        server.HasTrustedUrlSource.Should().BeFalse();
+    }
+
+    [Fact]
+    public static void HasTrustedUrlSource_ShouldReturnTrueWhenTrusted()
+    {
+        Server server = new("Unit Test", 0, "127.0.0.1", 0)
+        {
+            WinDownload = "https://unitystationfile.b-cdn.net/Windows",
+            OsxDownload = "https://unitystationfile.b-cdn.net/Mac",
+            LinuxDownload = "https://unitystationfile.b-cdn.net/Linux"
+        };
+
+        server.HasTrustedUrlSource.Should().BeTrue();
+    }
+    #endregion
+
+    #region Server.HasValidDomainName
+    [Fact]
+    public static void HasValidDomainName_ShouldReturnFalseWhenNull()
+    {
+#pragma warning disable CS8625
+        Server server = new("Unit Test", 0, null, 0);
+#pragma warning restore CS8625
+        server.HasValidDomainName.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("some invalid url <>@#*$(&")]
+    [InlineData(" ")]
+    [InlineData("")]
+    public static void HasValidDomainName_ShouldReturnFalseWhenInvalid(string serverIp)
+    {
+        Server server = new("Unit Test", 0, serverIp, 0);
+        server.HasValidDomainName.Should().BeFalse();
+    }
+
+    [Fact]
+    public static void HasValidDomainName_ShouldReturnTrueWhenValid()
+    {
+        Server server = new("Unit Test", 0, "na1.unitystation.org", 0);
+        server.HasValidDomainName.Should().BeTrue();
+    }
+    #endregion
+
+    #region Server.HasValidIpAddress
+    [Fact]
+    public static void HasValidIpAddress_ShouldReturnFalseWhenNull()
+    {
+#pragma warning disable CS8625
+        Server server = new("Unit Test", 0, null, 0);
+#pragma warning restore CS8625
+        server.HasValidIpAddress.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData(" ")]
+    [InlineData("")]
+    public static void HasValidIpAddress_ShouldReturnFalseWhenInvalid(string serverIp)
+    {
+        Server server = new("Unit Test", 0, serverIp, 0);
+        server.HasValidIpAddress.Should().BeFalse();
+    }
+
+    [Fact]
+    public static void HasValidIpAddress_ShouldReturnTrueWhenValid()
+    {
+        Server server = new("Unit Test", 0, "127.0.0.1", 0);
+        server.HasValidIpAddress.Should().BeTrue();
+    }
+    #endregion
+}

--- a/UnitystationLauncher.Tests/Models/ConfigFile/HubClientConfigTests.cs
+++ b/UnitystationLauncher.Tests/Models/ConfigFile/HubClientConfigTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using UnitystationLauncher.Models.ConfigFile;
+using UnitystationLauncher.Tests.MocksRepository;
+using Xunit;
+
+namespace UnitystationLauncher.Tests.Models.ConfigFile;
+
+public static class HubClientConfigTests
+{
+    private const string WindowsUrl = "windows";
+    private const string MacUrl = "mac";
+    private const string LinuxUrl = "linux";
+
+    private static readonly HubClientConfig _hubClientConfig = new()
+    {
+        WinUrl = WindowsUrl,
+        OsxUrl = MacUrl,
+        LinuxUrl = LinuxUrl,
+        BuildNumber = 0,
+        DailyMessage = "Unit Tests are nice"
+    };
+
+    #region HubClientConfig.GetDownloadUrl
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnLinuxUrlWhenPlatformIsLinux()
+    {
+        _hubClientConfig.GetDownloadUrl(MockEnvironmentService.GetLinuxStandaloneEnvironment()).Should().Be(LinuxUrl);
+    }
+
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnLinuxUrlWhenPlatformIsLinuxFlatpak()
+    {
+        _hubClientConfig.GetDownloadUrl(MockEnvironmentService.GetLinuxFlatpakEnvironment()).Should().Be(LinuxUrl);
+    }
+
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnWindowsUrlWhenPlatformIsWindows()
+    {
+        _hubClientConfig.GetDownloadUrl(MockEnvironmentService.GetWindowsStandaloneEnvironment()).Should().Be(WindowsUrl);
+    }
+
+    [Fact]
+    public static void GetDownloadUrl_ShouldReturnMacUrlWhenPlatformIsMac()
+    {
+        _hubClientConfig.GetDownloadUrl(MockEnvironmentService.GetMacStandaloneEnvironment()).Should().Be(MacUrl);
+    }
+    #endregion
+}

--- a/UnitystationLauncher.Tests/UnitystationLauncher.Tests.csproj
+++ b/UnitystationLauncher.Tests/UnitystationLauncher.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPublishable>false</IsPublishable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\UnitystationLauncher\UnitystationLauncher.csproj" />
+    </ItemGroup>
+
+    <Target Name="BundleApp" DependsOnTargets="Publish">
+        <!-- intentionally empty -->
+    </Target>
+
+</Project>

--- a/UnitystationLauncher.sln
+++ b/UnitystationLauncher.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29418.71
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitystationLauncher", "UnitystationLauncher\UnitystationLauncher.csproj", "{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitystationLauncher.Tests", "UnitystationLauncher.Tests\UnitystationLauncher.Tests.csproj", "{FC971561-155A-4B54-9977-203EA22663CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,24 @@ Global
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseWIN64|x64.Build.0 = ReleaseWIN64|x64
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|x64.ActiveCfg = ReleaseOSX|x64
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|x64.Build.0 = ReleaseOSX|x64
+		{FC971561-155A-4B54-9977-203EA22663CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.Release|x64.Build.0 = Release|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleasePOSIX64|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleasePOSIX64|Any CPU.Build.0 = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleasePOSIX64|x64.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleasePOSIX64|x64.Build.0 = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseWIN64|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseWIN64|Any CPU.Build.0 = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseWIN64|x64.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseWIN64|x64.Build.0 = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|x64.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|x64.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnitystationLauncher.sln.DotSettings
+++ b/UnitystationLauncher.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unitystation/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/UnitystationLauncher/Models/ConfigFile/HubClientConfig.cs
+++ b/UnitystationLauncher/Models/ConfigFile/HubClientConfig.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using UnitystationLauncher.Models.Enums;
+using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.Models.ConfigFile
 {
@@ -12,12 +14,16 @@ namespace UnitystationLauncher.Models.ConfigFile
         public string? LinuxUrl { get; set; }
         public string? DailyMessage { get; set; }
 
-        public string? GetDownloadUrl()
+        public string? GetDownloadUrl(IEnvironmentService environmentService)
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? WinUrl :
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? OsxUrl :
-                RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? LinuxUrl :
-                null;
+            return environmentService.GetCurrentEnvironment() switch
+            {
+                CurrentEnvironment.WindowsStandalone => WinUrl,
+                CurrentEnvironment.MacOsStandalone => OsxUrl,
+                CurrentEnvironment.LinuxStandalone
+                    or CurrentEnvironment.LinuxFlatpak => LinuxUrl,
+                _ => null
+            };
         }
     }
 }

--- a/UnitystationLauncher/Models/ForkInstall.cs
+++ b/UnitystationLauncher/Models/ForkInstall.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnitystationLauncher.Models.Api;
+
+namespace UnitystationLauncher.Models;
+
+public class ForkInstall
+{
+    public ForkInstall(Download? download, Installation? installation, IReadOnlyList<Server> servers)
+    {
+        Download = download;
+        Installation = installation;
+        Servers = servers;
+    }
+
+    public (string, int) ForkAndVersion =>
+        Download?.ForkAndVersion ??
+        Installation?.ForkAndVersion ??
+        Servers.FirstOrDefault()?.ForkAndVersion ??
+        throw new ArgumentNullException();
+
+    public Download? Download { get; }
+    public Installation? Installation { get; }
+    public IReadOnlyList<Server> Servers { get; }
+}

--- a/UnitystationLauncher/Models/Installation.cs
+++ b/UnitystationLauncher/Models/Installation.cs
@@ -24,7 +24,7 @@ namespace UnitystationLauncher.Models
         public string InstallationPath { get; }
         public (string, int) ForkAndVersion => (ForkName, BuildVersion);
 
-        private IEnvironmentService _environmentService;
+        private readonly IEnvironmentService _environmentService;
 
         public Installation(string folderPath, IPreferencesService preferencesService, IEnvironmentService environmentService)
         {

--- a/UnitystationLauncher/Services/InstallationService.cs
+++ b/UnitystationLauncher/Services/InstallationService.cs
@@ -134,6 +134,7 @@ namespace UnitystationLauncher.Services
         {
             _autoRemoveSub.Dispose();
             _fileWatcher.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/UnitystationLauncher/Services/InstallationService.cs
+++ b/UnitystationLauncher/Services/InstallationService.cs
@@ -15,7 +15,7 @@ using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.Services
 {
-    public class InstallationService : ReactiveObject, IInstallationService
+    public class InstallationService : ReactiveObject, IDisposable, IInstallationService
     {
         private readonly FileSystemWatcher _fileWatcher;
         private readonly IDisposable _autoRemoveSub;
@@ -71,7 +71,7 @@ namespace UnitystationLauncher.Services
                 .RefCount();
 
             _autoRemoveSub = preferences.WhenAnyValue(x => x.AutoRemove)
-                .CombineLatest(_installations, (a, installations) => installations)
+                .CombineLatest(_installations, (_, installations) => installations)
                 .Subscribe(RemoveOldVersions);
         }
 

--- a/UnitystationLauncher/Services/InstallationService.cs
+++ b/UnitystationLauncher/Services/InstallationService.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Runtime.InteropServices;
 using Mono.Unix;
 using ReactiveUI;
 using Serilog;
@@ -16,17 +15,20 @@ using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.Services
 {
-    public class InstallationService : ReactiveObject, IDisposable
+    public class InstallationService : ReactiveObject, IInstallationService
     {
-        private bool _autoRemove;
         private readonly FileSystemWatcher _fileWatcher;
         private readonly IDisposable _autoRemoveSub;
         private readonly IEnvironmentService _environmentService;
+        private readonly IPreferencesService _preferencesService;
+        private readonly IObservable<IReadOnlyList<Installation>> _installations;
 
         public InstallationService(IPreferencesService preferencesService, IEnvironmentService environmentService)
         {
-            Preferences preferences = preferencesService.GetPreferences();
+            _preferencesService = preferencesService;
             _environmentService = environmentService;
+
+            Preferences preferences = _preferencesService.GetPreferences();
             SetupInstallationPath(preferences.InstallationPath);
             _fileWatcher = new(preferences.InstallationPath)
             {
@@ -51,7 +53,7 @@ namespace UnitystationLauncher.Services
                 h => _fileWatcher.Renamed += h,
                 h => _fileWatcher.Renamed -= h);
 
-            Installations = changed
+            _installations = changed
                 .Merge(created)
                 .Merge(deleted)
                 .Merge(renamed)
@@ -61,30 +63,26 @@ namespace UnitystationLauncher.Services
                 .Merge(Observable.Return(Unit.Default))
                 .Select(f =>
                     Directory.EnumerateDirectories(preferences.InstallationPath)
-                        .Select(dir => new Installation(dir, preferencesService))
+                        .Select(dir => new Installation(dir, preferencesService, _environmentService))
                         .OrderByDescending(x => x.ForkName + x.BuildVersion)
                         .ToList())
                 .Do(x => Log.Information("Installations changed"))
                 .Replay(1)
                 .RefCount();
 
-            _autoRemoveSub = this.WhenAnyValue(x => x.AutoRemove)
-                .Merge(Observable.Return(_autoRemove))
-                .CombineLatest(Installations, (a, installations) => installations)
+            _autoRemoveSub = preferences.WhenAnyValue(x => x.AutoRemove)
+                .CombineLatest(_installations, (a, installations) => installations)
                 .Subscribe(RemoveOldVersions);
         }
 
-        public IObservable<IReadOnlyList<Installation>> Installations { get; }
-
-        public bool AutoRemove
+        public IObservable<IReadOnlyList<Installation>> GetInstallations()
         {
-            get => _autoRemove;
-            set => this.RaiseAndSetIfChanged(ref _autoRemove, value);
+            return _installations;
         }
 
         private void RemoveOldVersions(IReadOnlyList<Installation> installations)
         {
-            if (!_autoRemove)
+            if (!_preferencesService.GetPreferences().AutoRemove)
             {
                 return;
             }

--- a/UnitystationLauncher/Services/Interface/IInstallationService.cs
+++ b/UnitystationLauncher/Services/Interface/IInstallationService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using UnitystationLauncher.Models;
+
+namespace UnitystationLauncher.Services.Interface;
+
+public interface IInstallationService : IDisposable
+{
+    public IObservable<IReadOnlyList<Installation>> GetInstallations();
+
+    public new void Dispose();
+}

--- a/UnitystationLauncher/Services/Interface/IInstallationService.cs
+++ b/UnitystationLauncher/Services/Interface/IInstallationService.cs
@@ -4,9 +4,7 @@ using UnitystationLauncher.Models;
 
 namespace UnitystationLauncher.Services.Interface;
 
-public interface IInstallationService : IDisposable
+public interface IInstallationService
 {
     public IObservable<IReadOnlyList<Installation>> GetInstallations();
-
-    public new void Dispose();
 }

--- a/UnitystationLauncher/Services/Interface/IServerService.cs
+++ b/UnitystationLauncher/Services/Interface/IServerService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using UnitystationLauncher.Models.Api;
+
+namespace UnitystationLauncher.Services.Interface;
+
+public interface IServerService : IDisposable
+{
+    public IObservable<IReadOnlyList<Server>> GetServers();
+
+    public new void Dispose();
+}

--- a/UnitystationLauncher/Services/Interface/IServerService.cs
+++ b/UnitystationLauncher/Services/Interface/IServerService.cs
@@ -4,9 +4,7 @@ using UnitystationLauncher.Models.Api;
 
 namespace UnitystationLauncher.Services.Interface;
 
-public interface IServerService : IDisposable
+public interface IServerService
 {
     public IObservable<IReadOnlyList<Server>> GetServers();
-
-    public new void Dispose();
 }

--- a/UnitystationLauncher/Services/Interface/IStateService.cs
+++ b/UnitystationLauncher/Services/Interface/IStateService.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using UnitystationLauncher.Models;
+
+namespace UnitystationLauncher.Services.Interface;
+
+public interface IStateService
+{
+    public IObservable<IReadOnlyDictionary<(string ForkName, int BuildVersion), ForkInstall>> GetState();
+}

--- a/UnitystationLauncher/Services/ServerService.cs
+++ b/UnitystationLauncher/Services/ServerService.cs
@@ -13,7 +13,7 @@ using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.Services
 {
-    public class ServerService : ReactiveObject, IServerService
+    public class ServerService : ReactiveObject, IDisposable, IServerService
     {
         private readonly HttpClient _http;
         private readonly IInstallationService _installationService;

--- a/UnitystationLauncher/Services/ServerService.cs
+++ b/UnitystationLauncher/Services/ServerService.cs
@@ -13,7 +13,7 @@ using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.Services
 {
-    public class ServerService : ReactiveObject, IDisposable, IServerService
+    public class ServerService : ReactiveObject, IServerService
     {
         private readonly HttpClient _http;
         private readonly IInstallationService _installationService;
@@ -81,11 +81,6 @@ namespace UnitystationLauncher.Services
             }
 
             return true;
-        }
-
-        public void Dispose()
-        {
-            _installationService.Dispose();
         }
     }
 }

--- a/UnitystationLauncher/Services/StateService.cs
+++ b/UnitystationLauncher/Services/StateService.cs
@@ -13,7 +13,7 @@ namespace UnitystationLauncher.Services
 {
     public class StateService : IStateService
     {
-        private IObservable<IReadOnlyDictionary<(string ForkName, int BuildVersion), ForkInstall>> _state;
+        private readonly IObservable<IReadOnlyDictionary<(string ForkName, int BuildVersion), ForkInstall>> _state;
 
         public StateService(IServerService serverService, IInstallationService installationService, IDownloadService downloadService)
         {

--- a/UnitystationLauncher/Services/StateService.cs
+++ b/UnitystationLauncher/Services/StateService.cs
@@ -11,11 +11,13 @@ using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.Services
 {
-    public class StateService
+    public class StateService : IStateService
     {
-        public StateService(ServerService serverService, InstallationService installationService, IDownloadService downloadService)
+        private IObservable<IReadOnlyDictionary<(string ForkName, int BuildVersion), ForkInstall>> _state;
+
+        public StateService(IServerService serverService, IInstallationService installationService, IDownloadService downloadService)
         {
-            IObservable<IEnumerable<IGrouping<(string, int), Server>>> groupedServerEvents = serverService.Servers
+            IObservable<IEnumerable<IGrouping<(string, int), Server>>> groupedServerEvents = serverService.GetServers()
                 .Select(servers => servers
                     .GroupBy(s => s.ForkAndVersion));
 
@@ -25,9 +27,9 @@ namespace UnitystationLauncher.Services
                 .Select(d => downloads)
                 .Merge(Observable.Return(downloads));
 
-            IObservable<IReadOnlyList<Installation>> installationEvents = installationService.Installations;
+            IObservable<IReadOnlyList<Installation>> installationEvents = installationService.GetInstallations();
 
-            State = groupedServerEvents
+            _state = groupedServerEvents
                 .CombineLatest(installationEvents, (servers, installations) => (servers, installations))
                 .Select(d => d.servers.FullJoin(d.installations,
                     s => s.Key,
@@ -47,26 +49,9 @@ namespace UnitystationLauncher.Services
                 .RefCount();
         }
 
-        public IObservable<IReadOnlyDictionary<(string ForkName, int BuildVersion), ForkInstall>> State { get; }
-
-        public class ForkInstall
+        public IObservable<IReadOnlyDictionary<(string ForkName, int BuildVersion), ForkInstall>> GetState()
         {
-            public ForkInstall(Download? download, Installation? installation, IReadOnlyList<Server> servers)
-            {
-                Download = download;
-                Installation = installation;
-                Servers = servers;
-            }
-
-            public (string, int) ForkAndVersion =>
-                Download?.ForkAndVersion ??
-                Installation?.ForkAndVersion ??
-                Servers.FirstOrDefault()?.ForkAndVersion ??
-                throw new ArgumentNullException();
-
-            public Download? Download { get; }
-            public Installation? Installation { get; }
-            public IReadOnlyList<Server> Servers { get; }
+            return _state;
         }
     }
 }

--- a/UnitystationLauncher/StandardModule.cs
+++ b/UnitystationLauncher/StandardModule.cs
@@ -16,11 +16,9 @@ namespace UnitystationLauncher
             builder.RegisterType<PreferencesService>().As<IPreferencesService>().SingleInstance();
             builder.RegisterType<HubService>().As<IHubService>().SingleInstance();
             builder.RegisterType<DownloadService>().As<IDownloadService>().SingleInstance();
-
-            // Not yet interfaced
-            builder.RegisterType<InstallationService>().SingleInstance();
-            builder.RegisterType<ServerService>().SingleInstance();
-            builder.RegisterType<StateService>().SingleInstance();
+            builder.RegisterType<InstallationService>().As<IInstallationService>().SingleInstance();
+            builder.RegisterType<ServerService>().As<IServerService>().SingleInstance();
+            builder.RegisterType<StateService>().As<IStateService>().SingleInstance();
 
             // View Models
             builder.RegisterAssemblyTypes(ThisAssembly)

--- a/UnitystationLauncher/UnitystationLauncher.csproj
+++ b/UnitystationLauncher/UnitystationLauncher.csproj
@@ -35,6 +35,9 @@
     <NSHighResolutionCapable>true</NSHighResolutionCapable>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="UnitystationLauncher.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="**\*.xaml.cs">
       <DependentUpon>%(Filename)</DependentUpon>
     </Compile>

--- a/UnitystationLauncher/ViewModels/InstallationsPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/InstallationsPanelViewModel.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using MessageBox.Avalonia;
 using MessageBox.Avalonia.Models;
 using MessageBox.Avalonia.DTO;
-using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using UnitystationLauncher.Constants;
@@ -20,12 +19,13 @@ namespace UnitystationLauncher.ViewModels
         public override string Name => "Installations";
         public override bool IsEnabled => true;
 
-        private readonly InstallationService _installationService;
         string? _buildNum;
         private bool _autoRemove;
-        private readonly IPreferencesService _preferencesService;
 
-        public InstallationsPanelViewModel(InstallationService installationService, IPreferencesService preferencesService)
+        private readonly IPreferencesService _preferencesService;
+        private readonly IInstallationService _installationService;
+
+        public InstallationsPanelViewModel(IInstallationService installationService, IPreferencesService preferencesService)
         {
             _installationService = installationService;
             _preferencesService = preferencesService;
@@ -40,7 +40,7 @@ namespace UnitystationLauncher.ViewModels
             UpdateFromPreferences();
         }
 
-        public IObservable<IReadOnlyList<InstallationViewModel>> Installations => _installationService.Installations
+        public IObservable<IReadOnlyList<InstallationViewModel>> Installations => _installationService.GetInstallations()
             .Select(installations => installations
                 .Select(installation => new InstallationViewModel(installation)).ToList());
 
@@ -60,7 +60,6 @@ namespace UnitystationLauncher.ViewModels
         {
             Preferences prefs = _preferencesService.GetPreferences();
             AutoRemove = prefs.AutoRemove;
-            _installationService.AutoRemove = prefs.AutoRemove;
         }
 
         private async Task OnAutoRemoveChangedAsync()
@@ -97,7 +96,6 @@ namespace UnitystationLauncher.ViewModels
         {
             Preferences prefs = _preferencesService.GetPreferences();
             prefs.AutoRemove = AutoRemove;
-            _installationService.AutoRemove = AutoRemove;
         }
     }
 }

--- a/UnitystationLauncher/ViewModels/ServersPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/ServersPanelViewModel.cs
@@ -6,21 +6,20 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using ReactiveUI;
 using UnitystationLauncher.Models.Api;
-using UnitystationLauncher.Services;
 using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.ViewModels
 {
     public class ServersPanelViewModel : PanelBase
     {
-        private readonly StateService _stateService;
+        private readonly IStateService _stateService;
         private readonly IDownloadService _downloadService;
         private readonly IEnvironmentService _environmentService;
 
         public override string Name => "Servers";
         public override bool IsEnabled => true;
 
-        public ServersPanelViewModel(StateService stateService, IDownloadService downloadService, IEnvironmentService environmentService)
+        public ServersPanelViewModel(IStateService stateService, IDownloadService downloadService, IEnvironmentService environmentService)
         {
             _stateService = stateService;
             _downloadService = downloadService;
@@ -35,7 +34,7 @@ namespace UnitystationLauncher.ViewModels
 
         public ReactiveCommand<ServerViewModel, Unit> DownloadCommand { get; }
 
-        public IObservable<IReadOnlyList<ServerViewModel>> ServerList => _stateService.State
+        public IObservable<IReadOnlyList<ServerViewModel>> ServerList => _stateService.GetState()
             .Select(state => state
                 .SelectMany(installationState => installationState.Value.Servers
                     .Select(s => new ServerViewModel(s, installationState.Value.Installation, installationState.Value.Download, _environmentService)))


### PR DESCRIPTION
Changes:
- Adds Interfaces to the following services:
  - Installation Service
  - Server Service
  - State Service
- Creates a project for unit tests
- Adds initial unit tests for the following classes:
  - Models/Api/Server
  - Models/ConfigFile/HubClientConfig
  - Infrastructure/TaskExtensions
  
All services should have interfaces now, so anything not effected by #188 or #191 should be ready to have tests written.