### PR TITLE
Fix code coverage reporting not working in GH action

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -33,7 +33,7 @@ jobs:
           CODACY_PROJECT_NAME: stationhub
         run: |
           dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./opencover.xml'
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r opencover.xml
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r './UnitystationLauncher.Tests/opencover.xml'
 
   build-windows:
     name: Build Windows

--- a/.gitignore
+++ b/.gitignore
@@ -335,3 +335,5 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+**/opencover.xml

--- a/UnitystationLauncher.Tests/UnitystationLauncher.Tests.csproj
+++ b/UnitystationLauncher.Tests/UnitystationLauncher.Tests.csproj
@@ -9,6 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />


### PR DESCRIPTION
Adds the missing NuGet package and fixes the path of the coverage XML file.