### PR TITLE
Remove Codacy coverage

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "develop"
-  pull_request_target:
+  pull_request:
     branches:
       - "*"
 
@@ -26,14 +26,8 @@ jobs:
           dotnet format --verify-no-changes
 
       - name: Test
-        env:
-          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-          CODACY_ORGANIZATION_PROVIDER: gh
-          CODACY_USERNAME: unitystation
-          CODACY_PROJECT_NAME: stationhub
         run: |
-          dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./opencover.xml'
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r './UnitystationLauncher.Tests/opencover.xml'
+          dotnet test /p:CollectCoverage=true
 
   build-windows:
     name: Build Windows


### PR DESCRIPTION
Codacy code coverage is broken, this will revert it back to its pre-change state with the exception of calculating the coverage. The coverage % will be output in the command line output of the GH Action, which is better than nothing at least.

Would be nice if there was some sort of way to show the coverage on the PR itself, but thats a different change for a different day.