### PR TITLE
Fix error fetching blog posts stopping the client from opening and add unit test for this

### DIFF
--- a/UnitystationLauncher.Tests/MocksRepository/MockBlogService.cs
+++ b/UnitystationLauncher.Tests/MocksRepository/MockBlogService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Moq;
 using UnitystationLauncher.Models.Api.Changelog;
@@ -24,6 +25,13 @@ public class MockBlogService
         Mock<IBlogService> mock = new();
         mock.Setup(x => x.GetBlogPosts(It.IsAny<int>())).Returns(blogPosts);
 
+        return mock.Object;
+    }
+
+    public static IBlogService ThrowsException()
+    {
+        Mock<IBlogService> mock = new();
+        mock.Setup(x => x.GetBlogPosts(It.IsAny<int>())).Throws<Exception>();
         return mock.Object;
     }
 }

--- a/UnitystationLauncher.Tests/ViewModels/NewsPanelViewModelTests.cs
+++ b/UnitystationLauncher.Tests/ViewModels/NewsPanelViewModelTests.cs
@@ -18,7 +18,7 @@ public static class NewsPanelViewModelTests
         newsPanelViewModel.BlogPosts.Count.Should().Be(3);
         newsPanelViewModel.NewsHeader.Should().Be("News (1/3)");
     }
-    
+
     [Fact]
     public static void NewsPanelViewModel_ShouldHandleExceptionInBlogService()
     {

--- a/UnitystationLauncher.Tests/ViewModels/NewsPanelViewModelTests.cs
+++ b/UnitystationLauncher.Tests/ViewModels/NewsPanelViewModelTests.cs
@@ -18,6 +18,16 @@ public static class NewsPanelViewModelTests
         newsPanelViewModel.BlogPosts.Count.Should().Be(3);
         newsPanelViewModel.NewsHeader.Should().Be("News (1/3)");
     }
+    
+    [Fact]
+    public static void NewsPanelViewModel_ShouldHandleExceptionInBlogService()
+    {
+        IBlogService blogService = MockBlogService.ThrowsException();
+
+        NewsPanelViewModel newsPanelViewModel = new(null!, blogService);
+        newsPanelViewModel.NewsHeader.Should().Be("News (1/1)");
+        newsPanelViewModel.CurrentBlogPost.Title.Should().Be("Error fetching blog posts");
+    }
     #endregion
 
     #region NewsPanelViewModel.NextPost

--- a/UnitystationLauncher/ViewModels/NewsPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/NewsPanelViewModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using ReactiveUI;
 using System.Collections.ObjectModel;
 using System.Reactive;
-using System.Diagnostics;
+using Serilog;
 using UnitystationLauncher.Constants;
 using UnitystationLauncher.Models.Api.Changelog;
 using UnitystationLauncher.Services.Interface;
@@ -60,10 +60,12 @@ namespace UnitystationLauncher.ViewModels
 
         private void FetchBlogPosts()
         {
-            List<BlogPost>? blogPosts = _blogService.GetBlogPosts(5);
 
-            if (blogPosts != null)
+
+            try
             {
+                List<BlogPost> blogPosts = _blogService.GetBlogPosts(5);
+
                 foreach (BlogPost post in blogPosts)
                 {
                     string title = post.Title;
@@ -83,6 +85,16 @@ namespace UnitystationLauncher.ViewModels
 
                     BlogPosts.Add(new(title, link, summary, date, image));
                 }
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error fetching blog posts, adding default. Exception: {e.Message}");
+                BlogPosts.Add(new(
+                    "Error fetching blog posts", 
+                    LinkUrls.BlogBaseUrl, 
+                    "Click here to check the website for blog posts.", 
+                    DateOnly.FromDateTime(DateTime.Now), 
+                    null));
             }
         }
 

--- a/UnitystationLauncher/ViewModels/NewsPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/NewsPanelViewModel.cs
@@ -90,10 +90,10 @@ namespace UnitystationLauncher.ViewModels
             {
                 Log.Error($"Error fetching blog posts, adding default. Exception: {e.Message}");
                 BlogPosts.Add(new(
-                    "Error fetching blog posts", 
-                    LinkUrls.BlogBaseUrl, 
-                    "Click here to check the website for blog posts.", 
-                    DateOnly.FromDateTime(DateTime.Now), 
+                    "Error fetching blog posts",
+                    LinkUrls.BlogBaseUrl,
+                    "Click here to check the website for blog posts.",
+                    DateOnly.FromDateTime(DateTime.Now),
                     null));
             }
         }


### PR DESCRIPTION
Fixes an error when fetching blog posts causing the entire client to crash. The default post that is generated just uses the current date and has a direct link to the blog page on the site, though if something stops the posts from loading in the launcher the website will probably be broken for them as well.