### PR TITLE
.NET 8 Upgrade #223

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,7 @@ on:
       - "*"
 
 env:
-  DOTNET_VERSION: '7.0.x'
+  DOTNET_VERSION: '8.0.x'
 
 jobs:
   test:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -115,4 +115,4 @@ jobs:
       # Build
       - name: Test Flatpak Build
         run: |
-          dotnet publish --framework net7.0 --runtime linux-x64 --configuration Release --self-contained true /p:DefineConstants="FLATPAK" /p:DisableBeauty=true
+          dotnet publish --framework net8.0 --runtime linux-x64 --configuration Release --self-contained true /p:DefineConstants="FLATPAK" /p:DisableBeauty=true

--- a/UnitystationLauncher.Tests/UnitystationLauncher.Tests.csproj
+++ b/UnitystationLauncher.Tests/UnitystationLauncher.Tests.csproj
@@ -1,37 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <Nullable>enable</Nullable>
-
-        <IsPublishable>false</IsPublishable>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit" Version="2.6.4" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\UnitystationLauncher\UnitystationLauncher.csproj" />
-    </ItemGroup>
-
-    <Target Name="BundleApp" DependsOnTargets="Publish">
-        <!-- intentionally empty -->
-    </Target>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPublishable>false</IsPublishable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UnitystationLauncher\UnitystationLauncher.csproj" />
+  </ItemGroup>
+  <Target Name="BundleApp" DependsOnTargets="Publish">
+    <!-- intentionally empty -->
+  </Target>
 </Project>

--- a/UnitystationLauncher.sln
+++ b/UnitystationLauncher.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitystationLauncher", "UnitystationLauncher\UnitystationLauncher.csproj", "{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitystationLauncher", "UnitystationLauncher\UnitystationLauncher.csproj", "{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitystationLauncher.Tests", "UnitystationLauncher.Tests\UnitystationLauncher.Tests.csproj", "{FC971561-155A-4B54-9977-203EA22663CB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitystationLauncher.Tests", "UnitystationLauncher.Tests\UnitystationLauncher.Tests.csproj", "{FC971561-155A-4B54-9977-203EA22663CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/UnitystationLauncher.sln
+++ b/UnitystationLauncher.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29418.71
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitystationLauncher", "UnitystationLauncher\UnitystationLauncher.csproj", "{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitystationLauncher", "UnitystationLauncher\UnitystationLauncher.csproj", "{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitystationLauncher.Tests", "UnitystationLauncher.Tests\UnitystationLauncher.Tests.csproj", "{FC971561-155A-4B54-9977-203EA22663CB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitystationLauncher.Tests", "UnitystationLauncher.Tests\UnitystationLauncher.Tests.csproj", "{FC971561-155A-4B54-9977-203EA22663CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,11 +13,12 @@ Global
 		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
+		ReleaseOSX|Any CPU = ReleaseOSX|Any CPU
+		ReleaseOSX|x64 = ReleaseOSX|x64
 		ReleasePOSIX64|Any CPU = ReleasePOSIX64|Any CPU
 		ReleasePOSIX64|x64 = ReleasePOSIX64|x64
 		ReleaseWIN64|Any CPU = ReleaseWIN64|Any CPU
 		ReleaseWIN64|x64 = ReleaseWIN64|x64
-		ReleaseOSX|x64 = ReleaseOSX|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -28,6 +29,10 @@ Global
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.Release|x64.ActiveCfg = Release|x64
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.Release|x64.Build.0 = Release|x64
+		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|Any CPU.ActiveCfg = ReleaseOSX|x64
+		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|Any CPU.Build.0 = ReleaseOSX|x64
+		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|x64.ActiveCfg = ReleaseOSX|x64
+		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|x64.Build.0 = ReleaseOSX|x64
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleasePOSIX64|Any CPU.ActiveCfg = ReleasePOSIX64|Any CPU
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleasePOSIX64|Any CPU.Build.0 = ReleasePOSIX64|Any CPU
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleasePOSIX64|x64.ActiveCfg = ReleasePOSIX64|x64
@@ -36,8 +41,6 @@ Global
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseWIN64|Any CPU.Build.0 = ReleaseWIN64|Any CPU
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseWIN64|x64.ActiveCfg = ReleaseWIN64|x64
 		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseWIN64|x64.Build.0 = ReleaseWIN64|x64
-		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|x64.ActiveCfg = ReleaseOSX|x64
-		{B7F5B4B3-BD06-46DF-AD15-634B00004CDB}.ReleaseOSX|x64.Build.0 = ReleaseOSX|x64
 		{FC971561-155A-4B54-9977-203EA22663CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -46,6 +49,10 @@ Global
 		{FC971561-155A-4B54-9977-203EA22663CB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.Release|x64.ActiveCfg = Release|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.Release|x64.Build.0 = Release|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|Any CPU.ActiveCfg = Release|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|Any CPU.Build.0 = Release|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|x64.ActiveCfg = Debug|Any CPU
+		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|x64.Build.0 = Debug|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.ReleasePOSIX64|Any CPU.ActiveCfg = Debug|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.ReleasePOSIX64|Any CPU.Build.0 = Debug|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.ReleasePOSIX64|x64.ActiveCfg = Debug|Any CPU
@@ -54,8 +61,6 @@ Global
 		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseWIN64|Any CPU.Build.0 = Debug|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseWIN64|x64.ActiveCfg = Debug|Any CPU
 		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseWIN64|x64.Build.0 = Debug|Any CPU
-		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|x64.ActiveCfg = Debug|Any CPU
-		{FC971561-155A-4B54-9977-203EA22663CB}.ReleaseOSX|x64.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnitystationLauncher/UnitystationLauncher.csproj
+++ b/UnitystationLauncher/UnitystationLauncher.csproj
@@ -111,7 +111,6 @@
     <PackageReference Include="runtime.any.System.Threading.Timer" Version="4.3.0" />
     <PackageReference Include="runtime.unix.System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
-    <PackageReference Include="Microsoft.ILVerification" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="CodeScanList.json" />

--- a/UnitystationLauncher/UnitystationLauncher.csproj
+++ b/UnitystationLauncher/UnitystationLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
     <Nullable>enable</Nullable>
@@ -24,14 +24,16 @@
     <DisablePatch>False</DisablePatch>
     <!-- valid values: Error|Detail|Info -->
     <BeautyLogLevel>Error</BeautyLogLevel>
-    <CFBundleName>StationHub</CFBundleName> <!-- Also defines .app file name -->
+    <CFBundleName>StationHub</CFBundleName>
+    <!-- Also defines .app file name -->
     <CFBundleIdentifier>org.unitystation.hub</CFBundleIdentifier>
     <CFBundleVersion>1.0.0</CFBundleVersion>
     <CFBundleShortVersionString>1.0.0</CFBundleShortVersionString>
     <CFBundlePackageType>APPL</CFBundlePackageType>
     <CFBundleSignature>????</CFBundleSignature>
     <CFBundleExecutable>StationHub</CFBundleExecutable>
-    <CFBundleIconFile>ian.icns</CFBundleIconFile> <!-- Will be copied from output directory -->
+    <CFBundleIconFile>ian.icns</CFBundleIconFile>
+    <!-- Will be copied from output directory -->
     <NSPrincipalClass>NSApplication</NSPrincipalClass>
     <NSHighResolutionCapable>true</NSHighResolutionCapable>
   </PropertyGroup>
@@ -109,6 +111,7 @@
     <PackageReference Include="runtime.any.System.Threading.Timer" Version="4.3.0" />
     <PackageReference Include="runtime.unix.System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
+    <PackageReference Include="Microsoft.ILVerification" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="CodeScanList.json" />


### PR DESCRIPTION
fix(upgrade): Upgrade to .NET 8
fix(update): Update dotnetcore.ym

Please note it's crucial to ensure that your Visual Studio 2022 IDE is updated to the most current version (17.8+) as it supports .NET 8.0 and the SDK is installed as well. 

During this Upgrade, 
Error : 0
Warning: 1

Microsoft.NET.Sdk.targets(284,5): Warning NETSDK1206 : Found version-specific or distribution-specific runtime identifier(s): win7-x64, win7-x86. Affected libraries: Avalonia.Angle.Windows.Natives. In .NET 8.0 and higher, assets for version-specific and distribution-specific runtime identifiers will not be found by default. See https://aka.ms/dotnet/rid-usage for details.
