### PR TITLE
Move settings from Installations to Preferences

### DIFF
--- a/UnitystationLauncher/ViewModels/InstallationsPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/InstallationsPanelViewModel.cs
@@ -5,15 +5,9 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
-using System.Threading.Tasks;
-using MsBox.Avalonia.Base;
 using Serilog;
 using UnitystationLauncher.Constants;
-using UnitystationLauncher.Infrastructure;
 using UnitystationLauncher.Models;
-using UnitystationLauncher.Models.ConfigFile;
-using UnitystationLauncher.Models.Enums;
-using UnitystationLauncher.Services;
 using UnitystationLauncher.Services.Interface;
 
 namespace UnitystationLauncher.ViewModels
@@ -22,132 +16,17 @@ namespace UnitystationLauncher.ViewModels
     {
         public override string Name => "Installations";
         public override bool IsEnabled => true;
-
-        private string? _buildNum;
-        public string? BuildNum
-        {
-            get => _buildNum;
-            set => this.RaiseAndSetIfChanged(ref _buildNum, value);
-        }
-
-        private bool _autoRemove;
-        public bool AutoRemove
-        {
-            get => _autoRemove;
-            set => this.RaiseAndSetIfChanged(ref _autoRemove, value);
-        }
-
-        private bool? _TTSEnabled;
-
-        public bool? TTSEnabled
-        {
-            get => _TTSEnabled;
-            set => this.RaiseAndSetIfChanged(ref _TTSEnabled, value);
-        }
-
+        public static string? BuildNum => $"Hub Build Number: {AppInfo.CurrentBuild}";
         public ObservableCollection<InstallationViewModel> InstallationViews { get; init; } = new();
 
         private readonly TimeSpan _refreshInterval = TimeSpan.FromSeconds(2);
-        private readonly IPreferencesService _preferencesService;
         private readonly IInstallationService _installationService;
-        private readonly IEnvironmentService _environmentService;
-        private readonly ITTSService _ttsService;
 
-        public InstallationsPanelViewModel(IInstallationService installationService,
-            IPreferencesService preferencesService,
-            IEnvironmentService environmentService,
-            ITTSService ttsService
-            )
+        public InstallationsPanelViewModel(IInstallationService installationService)
         {
             _installationService = installationService;
-            _preferencesService = preferencesService;
-            _environmentService = environmentService;
-
-            _ttsService = ttsService;
-
-            BuildNum = $"Hub Build Num: {AppInfo.CurrentBuild}";
-
-            UpdateFromPreferences();
-
-            this.WhenAnyValue(p => p.AutoRemove)
-                .Select(_ => Observable.FromAsync(OnAutoRemoveChangedAsync))
-                .Concat()
-                .Subscribe();
-
-            this.WhenAnyValue(p => p.TTSEnabled)
-                .Select(_ => Observable.FromAsync(OnTTSChange))
-                .Concat()
-                .Subscribe();
-
 
             InitializeInstallationsList();
-        }
-
-        private void UpdateFromPreferences()
-        {
-            Preferences prefs = _preferencesService.GetPreferences();
-            AutoRemove = prefs.AutoRemove;
-            TTSEnabled = prefs.TTSEnabled;
-        }
-
-        private async Task OnAutoRemoveChangedAsync()
-        {
-
-
-            if (AutoRemove)
-            {
-                IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.YesNo,
-                    "Are you sure?", "This will remove older installations from disk. Proceed?");
-
-                string response = await msgBox.ShowAsync();
-                if (response.Equals(MessageBoxResults.Yes))
-                {
-                    SaveChoice();
-                }
-                else
-                {
-                    AutoRemove = false;
-                }
-            }
-            else
-            {
-                SaveChoice();
-            }
-        }
-
-        private async Task OnTTSChange()
-        {
-            if (_environmentService.GetCurrentEnvironment() == CurrentEnvironment.MacOsStandalone)
-            {
-                IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.Ok,
-                    " Mac Support is sad ",
-                    " Sadly TTS is unsupported on Mac, If you'd like to contribute this, feel free to shoot a message on the Discord. ");
-                string response = await msgBox.ShowAsync();
-                return;
-            }
-
-
-            if (TTSEnabled is false)
-            {
-                IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.YesNo,
-                    "Are you sure?", "This will disable Character voices (TTS). Proceed? (If yes It can take a little bit to delete So be patient)");
-
-                string response = await msgBox.ShowAsync();
-                if (response.Equals(MessageBoxResults.Yes))
-                {
-                    TTSEnabled = false;
-                    SaveChoiceTTS();
-                }
-                else
-                {
-                    TTSEnabled = true;
-                    SaveChoiceTTS();
-                }
-            }
-            else
-            {
-                SaveChoiceTTS();
-            }
         }
 
         private void InitializeInstallationsList()
@@ -200,30 +79,6 @@ namespace UnitystationLauncher.ViewModels
                     InstallationViews.Remove(viewModel);
                 }
             }
-        }
-
-        private void SaveChoice()
-        {
-            Preferences prefs = _preferencesService.GetPreferences();
-            prefs.AutoRemove = AutoRemove;
-        }
-
-        private void SaveChoiceTTS()
-        {
-            Preferences prefs = _preferencesService.GetPreferences();
-            prefs.TTSEnabled = TTSEnabled;
-
-            if (TTSEnabled == false)
-            {
-                _ttsService.StopTTS();
-                string installationBasePath = _preferencesService.GetPreferences().InstallationPath;
-                var LocalVersion = System.IO.Path.Combine(installationBasePath, "tts");
-                if (System.IO.Directory.Exists(LocalVersion))
-                {
-                    System.IO.Directory.Delete(LocalVersion, true);
-                }
-            }
-
         }
 
         public override void Refresh()

--- a/UnitystationLauncher/ViewModels/InstallationsPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/InstallationsPanelViewModel.cs
@@ -16,7 +16,6 @@ namespace UnitystationLauncher.ViewModels
     {
         public override string Name => "Installations";
         public override bool IsEnabled => true;
-        public static string? BuildNum => $"Hub Build Number: {AppInfo.CurrentBuild}";
         public ObservableCollection<InstallationViewModel> InstallationViews { get; init; } = new();
 
         private readonly TimeSpan _refreshInterval = TimeSpan.FromSeconds(2);

--- a/UnitystationLauncher/ViewModels/PreferencesPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/PreferencesPanelViewModel.cs
@@ -1,11 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using System.Reactive.Linq;
 using MsBox.Avalonia.Base;
 using ReactiveUI;
 using Serilog;
 using UnitystationLauncher.Constants;
 using UnitystationLauncher.Infrastructure;
-using UnitystationLauncher.Models.Enums;
 using UnitystationLauncher.Services.Interface;
+using UnitystationLauncher.Models.Enums;
+using UnitystationLauncher.Models.ConfigFile;
+using DynamicData.Binding;
 
 namespace UnitystationLauncher.ViewModels
 {
@@ -21,17 +25,104 @@ namespace UnitystationLauncher.ViewModels
             get => _installationPath;
             set => this.RaiseAndSetIfChanged(ref _installationPath, value);
         }
+        private bool _autoRemove;
+        public bool AutoRemove
+        {
+            get => _autoRemove;
+            set => this.RaiseAndSetIfChanged(ref _autoRemove, value);
+        }
+		// for a future overhaul of TTS
+        // private string TTSPath;
+        // public string TTSText
+        // { // exp ? true : false
+        //     get { return string.IsNullOrEmpty(TTSPath) ? "Not Installed." : $"Is Installed at {TTSPath}"; }
+        // }
+        // public string TTSButtonText
+        // {
+        //     get { return string.IsNullOrEmpty(TTSPath) ? "Install" : "Uninstall"; }
+        // }
+        private bool? _TTSEnabled;
+
+        public bool? TTSEnabled
+        {
+            get => _TTSEnabled;
+            set => this.RaiseAndSetIfChanged(ref _TTSEnabled, value);
+        }
 
         private readonly IPreferencesService _preferencesService;
         private readonly IInstallationService _installationService;
+		private readonly IEnvironmentService _environmentService;
+		private readonly ITTSService _ttsService;
 
-        public PreferencesPanelViewModel(IPreferencesService preferencesService, IInstallationService installationService)
+        public PreferencesPanelViewModel(
+			IPreferencesService preferencesService, 
+			IInstallationService installationService,
+			IEnvironmentService environmentService,
+			ITTSService ttsService)
         {
             _preferencesService = preferencesService;
             _installationService = installationService;
+			_environmentService = environmentService;
+			_ttsService = ttsService;
 
-            _installationPath = _preferencesService.GetPreferences().InstallationPath;
+			Preferences preferences = _preferencesService.GetPreferences();
+            _installationPath = preferences.InstallationPath;
+			_autoRemove = preferences.AutoRemove;
+			_TTSEnabled = preferences.TTSEnabled;
+			this.WhenAnyValue(p => p.AutoRemove)
+                .Select(_ => Observable.FromAsync(OnAutoRemoveChangedAsync))
+                .Concat()
+                .Subscribe();
+
+            this.WhenAnyValue(p => p.TTSEnabled)
+                .Select(_ => Observable.FromAsync(OnTTSChangedAsync))
+                .Concat()
+                .Subscribe();
         }
+
+		public async Task OnAutoRemoveChangedAsync() {
+			if (AutoRemove)
+            {
+                IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.YesNo,
+                    "Are you sure?", "This will remove older installations from disk. Proceed?");
+
+                string response = await msgBox.ShowAsync();
+				AutoRemove = response.Equals(MessageBoxResults.Yes);
+            }
+			_preferencesService.GetPreferences().AutoRemove = AutoRemove;
+		}
+
+		public async Task OnTTSChangedAsync() {
+			if (_environmentService.GetCurrentEnvironment() == CurrentEnvironment.MacOsStandalone)
+            {
+                IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.Ok,
+                    " MacOS is unsupported ",
+                    " Text-To-Speech is not supported on MacOS. If you would like to contribute, talk to us on the discord. ");
+                await msgBox.ShowAsync(); //should this even be awaited?
+                return;
+            }
+
+
+            if (TTSEnabled is false)
+            {
+                IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.YesNo,
+                    "Are you sure?", "This will disable Character voices and delete the TTS System. This may take a While.");
+                string response = await msgBox.ShowAsync();
+				TTSEnabled = response.Equals(MessageBoxResults.No);
+            }
+        	_preferencesService.GetPreferences().TTSEnabled = TTSEnabled;
+
+            if (TTSEnabled == false)
+            {
+                _ttsService.StopTTS();
+                string installationBasePath = _preferencesService.GetPreferences().InstallationPath; //yucky
+                var LocalVersion = System.IO.Path.Combine(installationBasePath, "tts");
+                if (System.IO.Directory.Exists(LocalVersion))
+                {
+                    System.IO.Directory.Delete(LocalVersion, true);
+                }
+            }
+		}
 
         public async Task SetInstallationPathAsync(string path)
         {

--- a/UnitystationLauncher/ViewModels/PreferencesPanelViewModel.cs
+++ b/UnitystationLauncher/ViewModels/PreferencesPanelViewModel.cs
@@ -31,7 +31,7 @@ namespace UnitystationLauncher.ViewModels
             get => _autoRemove;
             set => this.RaiseAndSetIfChanged(ref _autoRemove, value);
         }
-		// for a future overhaul of TTS
+        // for a future overhaul of TTS
         // private string TTSPath;
         // public string TTSText
         // { // exp ? true : false
@@ -51,25 +51,25 @@ namespace UnitystationLauncher.ViewModels
 
         private readonly IPreferencesService _preferencesService;
         private readonly IInstallationService _installationService;
-		private readonly IEnvironmentService _environmentService;
-		private readonly ITTSService _ttsService;
+        private readonly IEnvironmentService _environmentService;
+        private readonly ITTSService _ttsService;
 
         public PreferencesPanelViewModel(
-			IPreferencesService preferencesService, 
-			IInstallationService installationService,
-			IEnvironmentService environmentService,
-			ITTSService ttsService)
+            IPreferencesService preferencesService,
+            IInstallationService installationService,
+            IEnvironmentService environmentService,
+            ITTSService ttsService)
         {
             _preferencesService = preferencesService;
             _installationService = installationService;
-			_environmentService = environmentService;
-			_ttsService = ttsService;
+            _environmentService = environmentService;
+            _ttsService = ttsService;
 
-			Preferences preferences = _preferencesService.GetPreferences();
+            Preferences preferences = _preferencesService.GetPreferences();
             _installationPath = preferences.InstallationPath;
-			_autoRemove = preferences.AutoRemove;
-			_TTSEnabled = preferences.TTSEnabled;
-			this.WhenAnyValue(p => p.AutoRemove)
+            _autoRemove = preferences.AutoRemove;
+            _TTSEnabled = preferences.TTSEnabled;
+            this.WhenAnyValue(p => p.AutoRemove)
                 .Select(_ => Observable.FromAsync(OnAutoRemoveChangedAsync))
                 .Concat()
                 .Subscribe();
@@ -80,20 +80,22 @@ namespace UnitystationLauncher.ViewModels
                 .Subscribe();
         }
 
-		public async Task OnAutoRemoveChangedAsync() {
-			if (AutoRemove)
+        public async Task OnAutoRemoveChangedAsync()
+        {
+            if (AutoRemove)
             {
                 IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.YesNo,
                     "Are you sure?", "This will remove older installations from disk. Proceed?");
 
                 string response = await msgBox.ShowAsync();
-				AutoRemove = response.Equals(MessageBoxResults.Yes);
+                AutoRemove = response.Equals(MessageBoxResults.Yes);
             }
-			_preferencesService.GetPreferences().AutoRemove = AutoRemove;
-		}
+            _preferencesService.GetPreferences().AutoRemove = AutoRemove;
+        }
 
-		public async Task OnTTSChangedAsync() {
-			if (_environmentService.GetCurrentEnvironment() == CurrentEnvironment.MacOsStandalone)
+        public async Task OnTTSChangedAsync()
+        {
+            if (_environmentService.GetCurrentEnvironment() == CurrentEnvironment.MacOsStandalone)
             {
                 IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.Ok,
                     " MacOS is unsupported ",
@@ -108,9 +110,9 @@ namespace UnitystationLauncher.ViewModels
                 IMsBox<string> msgBox = MessageBoxBuilder.CreateMessageBox(MessageBoxButtons.YesNo,
                     "Are you sure?", "This will disable Character voices and delete the TTS System. This may take a While.");
                 string response = await msgBox.ShowAsync();
-				TTSEnabled = response.Equals(MessageBoxResults.No);
+                TTSEnabled = response.Equals(MessageBoxResults.No);
             }
-        	_preferencesService.GetPreferences().TTSEnabled = TTSEnabled;
+            _preferencesService.GetPreferences().TTSEnabled = TTSEnabled;
 
             if (TTSEnabled == false)
             {
@@ -122,7 +124,7 @@ namespace UnitystationLauncher.ViewModels
                     System.IO.Directory.Delete(LocalVersion, true);
                 }
             }
-		}
+        }
 
         public async Task SetInstallationPathAsync(string path)
         {

--- a/UnitystationLauncher/Views/InstallationsPanelView.xaml
+++ b/UnitystationLauncher/Views/InstallationsPanelView.xaml
@@ -13,15 +13,6 @@
     </Design.DataContext>
     
     <DockPanel>
-        <DockPanel DockPanel.Dock="Top" Background="#1d3b50">
-            <TextBlock DockPanel.Dock="Left" Margin="5" Text="{Binding BuildNum}" />
-            <CheckBox DockPanel.Dock="Right" Margin="5" IsChecked="{Binding AutoRemove}" HorizontalAlignment="Right">
-                <TextBlock Text=" Automatically Remove Old Versions" />
-            </CheckBox>
-            <CheckBox DockPanel.Dock="Right" Margin="5" IsChecked="{Binding TTSEnabled}" HorizontalAlignment="Right">
-                <TextBlock Text=" Run and download TTS(Voice generation) local server" />
-            </CheckBox>
-        </DockPanel>
         <ScrollViewer>
             <StackPanel>
                 <ItemsControl ItemsSource="{Binding InstallationViews}" />

--- a/UnitystationLauncher/Views/PreferencesPanelView.xaml
+++ b/UnitystationLauncher/Views/PreferencesPanelView.xaml
@@ -27,7 +27,8 @@
                     <RowDefinition Height="0.13*" />
                     <RowDefinition Height="0.13*" />
                     <RowDefinition Height="0.13*" />
-                    <RowDefinition Height="0.2*" />
+                    <RowDefinition Height="0.13*" />
+					<!-- not needed anymore? -->
                     <RowDefinition Height="0.2*" />
                     <RowDefinition Height="0.21*" />
                 </Grid.RowDefinitions>
@@ -48,67 +49,26 @@
                         <TextBlock FontSize="18" TextAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" Text="Change" />    
                     </Button>
                 </Grid>
-                <!--Grid Grid.Row="2" Margin="0 5 0 5">
-                    <TextBlock Grid.Column="0" FontSize="12" IsVisible="{Binding InvalidInstallationPath}" Text="Invalid installation path selected, please choose an empty directory with only ASCII characters in the path."/>
-                    <TextBlock Grid.Column="0" FontSize="12" IsVisible="{Binding RestartClientPrompt}" Text="Your installation path has been set, please restart StationHub for this change to take effect."/>
-                </Grid-->
-                    <!--Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="0.8*" />
-                        <ColumnDefinition Width="0.2*" />
-                    </Grid.ColumnDefinitions>
-                    <Border Background="#1d3b50" Grid.Column="0" BorderBrush="#ffffff" BorderThickness="0.4"
-                            Margin="0 0 5 0">
-                        <TextBlock FontSize="20" TextAlignment="Center" VerticalAlignment="Center" FontWeight="Bold">Screen mode</TextBlock>
-                    </Border>
-                    <ComboBox Grid.Column="1" Margin="5 0 0 0" Background="#1d3b50" />
-                </Grid-->
-                <!--Grid Grid.Row="3" Margin="0 5 0 0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="0.1*" />
-                        <ColumnDefinition Width="0.35*" />
-                        <ColumnDefinition Width="0.55*" />
-                    </Grid.ColumnDefinitions>
-                    <Viewbox Grid.Column="0" Margin="0 5 0 0" HorizontalAlignment="Left">
-                        <CheckBox Background="#1d3b50" BorderThickness="0" />
-                    </Viewbox>
-                    <StackPanel Grid.Column="1">
-                        <TextBlock FontSize="20" FontWeight="Bold" TextAlignment="Left">Allow auto updates</TextBlock>
-                        <TextBlock TextWrapping="Wrap" FontSize="12" FontWeight="Bold" TextAlignment="Left">The game and hub will automatically update</TextBlock>
-                    </StackPanel>
-                </Grid-->
-                <!--Grid Grid.Row="4" Margin="0 5 0 0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="0.1*" />
-                        <ColumnDefinition Width="0.35*" />
-                        <ColumnDefinition Width="0.55*" />
-                    </Grid.ColumnDefinitions>
-                    <Viewbox Grid.Column="0" Margin="0 5 0 0" HorizontalAlignment="Left">
-                        <CheckBox Background="#1d3b50" BorderThickness="0" />
-                    </Viewbox>
-                    <StackPanel Grid.Column="1">
-                        <TextBlock FontSize="20" FontWeight="Bold" TextAlignment="Left">Clear cache</TextBlock>
-                        <TextBlock TextWrapping="Wrap" FontSize="12" FontWeight="Bold" TextAlignment="Left">Clear cache the next time client starts</TextBlock>
-                    </StackPanel>
-                </Grid-->
-                <!--Grid Grid.Row="5" Margin="0 10 0 0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition />
-                        <ColumnDefinition />
-                    </Grid.ColumnDefinitions>
-                    <Button Margin="10 10 5 10" Grid.Column="0" BorderThickness="0.5" Background="#1d3b50"
-                            BorderBrush="#fcfcfd">
-                        <TextBlock FontSize="18" FontWeight="Bold" TextAlignment="Center">
-                            Accept
-                        </TextBlock>
-                    </Button>
-                    <Button Margin="5 10 10 10" Grid.Column="1" BorderThickness="0.5" Background="#1d3b50"
-                            BorderBrush="#fcfcfd">
-                        <TextBlock FontSize="18" FontWeight="Bold" TextAlignment="Center">
-                            Cancel
-                        </TextBlock>
-                    </Button>
-                </Grid-->
+                <Grid Grid.Row="2">
+                    <CheckBox DockPanel.Dock="Right" Margin="5" IsChecked="{Binding AutoRemove}" HorizontalAlignment="Left">
+                        <TextBlock VerticalAlignment="Center" FontSize="16" Text=" Automatically Remove Old Installations" />
+                    </CheckBox>
+                </Grid>
+				<!-- For a future overhaul of TTS... soonly.... -->
+				<!-- <Grid Grid.Row="3">
+					<StackPanel Margin="5" Orientation="Horizontal" VerticalAlignment="Center">
+						<TextBlock Text="TTS is: "/>
+						<TextBlock Text="{Binding TTSText}"/>
+						<Button VerticalAlignment="Top" Margin = "5, 0, 0, 0">
+							<TextBlock Text="{Binding TTSButtonText}"/>
+						</Button>
+					</StackPanel>
+				</Grid> -->
+                <Grid Grid.Row="3">
+                    <CheckBox DockPanel.Dock="Right" Margin="5" IsChecked="{Binding TTSEnabled}" HorizontalAlignment="Left">
+                        <TextBlock FontSize="16" VerticalAlignment="Center"> Enable the Text-To-Speech System </TextBlock>
+                    </CheckBox>
+                </Grid>
             </Grid>
         </Grid>
     </Grid>


### PR DESCRIPTION
Moves AutoRemove, TTS Settings from Installations into Preferences
Removes the Build Number display from Installations
Minor cleanup of commented-out no longer useful XAML in the Preferences menu